### PR TITLE
Fix self-update restart on macOS

### DIFF
--- a/src/rigbook/routes/update.py
+++ b/src/rigbook/routes/update.py
@@ -63,14 +63,10 @@ def _spawn_and_exit(exe_path: str) -> None:
         else:
             if "--no-browser" not in args:
                 args = args + ["--no-browser"]
-            devnull = open(os.devnull, "w")
             subprocess.Popen(
                 [exe_path] + args,
                 env=env,
                 start_new_session=True,
-                stdin=subprocess.DEVNULL,
-                stdout=devnull,
-                stderr=devnull,
             )
         logger.info("Spawned new process, shutting down...")
         os._exit(0)


### PR DESCRIPTION
When launched from Finder, macOS Terminal.app appends `; exit;` to the command, causing the terminal to close after the old process exits. The spawned new process would fail or become invisible.

- Use `open` to relaunch the binary on macOS, giving the user a fresh Terminal.app window after update
- Keep existing `Popen` behavior on Linux/Windows where this isn't an issue