### PR TITLE
Double-column hamburger menu on short viewports

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2184,6 +2184,19 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    max-height: calc(100vh - 4rem);
+    overflow-y: auto;
+  }
+
+  @media (max-height: 600px) {
+    .menu {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      min-width: 280px;
+    }
+    .menu-separator {
+      grid-column: 1 / -1;
+    }
   }
 
   .menu-item {


### PR DESCRIPTION
## Summary

- Hamburger menu switches to 2-column grid layout when viewport height < 600px (fixes #140)
- Menu has max-height with overflow-y auto as safety net on all screen sizes
- Menu separators span both columns in grid mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)