### PR TITLE
Clean up stale lock files on startup and in logbook listing

### DIFF
--- a/src/rigbook/db.py
+++ b/src/rigbook/db.py
@@ -706,8 +706,24 @@ async def resolve_setting(
     return default
 
 
+def cleanup_stale_locks() -> None:
+    """Remove .lock and .addr files left behind by dead processes."""
+    for lock_path in DB_DIR.glob("*.lock"):
+        try:
+            with open(lock_path, "r+") as f:
+                _lock_exclusive(f)
+                _unlock(f)
+            # Lock acquired successfully — no live process holds it; remove stale files
+            lock_path.unlink(missing_ok=True)
+            lock_path.with_suffix(".addr").unlink(missing_ok=True)
+            logger.info("Removed stale lock file: %s", lock_path.name)
+        except OSError:
+            pass  # Genuinely locked by another process
+
+
 async def init_db() -> None:
     DB_DIR.mkdir(parents=True, exist_ok=True)
+    cleanup_stale_locks()
     await db_manager.open_global()
     # Check global default_pick_mode if no CLI override or --pick flag
     if (

--- a/src/rigbook/routes/logbooks.py
+++ b/src/rigbook/routes/logbooks.py
@@ -51,7 +51,10 @@ async def get_mode():
 
 
 def _is_locked(db_path) -> bool:
-    """Check if a logbook database is locked by another process."""
+    """Check if a logbook database is locked by another process.
+
+    Also cleans up stale lock files left behind by dead processes.
+    """
     lock_path = db_path.with_suffix(".lock")
     if not lock_path.exists():
         return False
@@ -59,6 +62,9 @@ def _is_locked(db_path) -> bool:
         with open(lock_path, "r+") as f:
             _lock_exclusive(f)
             _unlock(f)
+        # Stale lock — remove it
+        lock_path.unlink(missing_ok=True)
+        lock_path.with_suffix(".addr").unlink(missing_ok=True)
         return False
     except OSError:
         return True


### PR DESCRIPTION
## Summary
- Add `cleanup_stale_locks()` that runs at startup to remove `.lock`/`.addr` files left behind by dead processes (e.g. after SIGKILL)
- Update `_is_locked()` in logbook listing to also clean up stale lock files, so the picker UI doesn't show false locks

Fixes #147