### PR TITLE
QRZ Logbook API integration (#166)

### DIFF
--- a/frontend/src/ExportImport.svelte
+++ b/frontend/src/ExportImport.svelte
@@ -567,6 +567,7 @@
       if (res.ok) {
         await fetchQrzSyncStatus();
         expandedRow = null;
+        if (qrzExcludedCount === 0) qrzFilter = "pending";
       }
     } catch {}
   }

--- a/frontend/src/ExportImport.svelte
+++ b/frontend/src/ExportImport.svelte
@@ -1907,7 +1907,7 @@
 
   .qrz-detail-actions {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     gap: 0.75rem;
     margin-bottom: 0.75rem;
     padding-bottom: 0.75rem;

--- a/frontend/src/ExportImport.svelte
+++ b/frontend/src/ExportImport.svelte
@@ -9,6 +9,7 @@
   let message = "";
   let messageType = "";
   let qrzImporting = false;
+  let hasQrzApiKey = false;
 
   // QRZ sync state
   let qrzSyncStatus = null;
@@ -151,9 +152,16 @@
     if (byAlias) { countryFilter = byAlias.name; return; }
   }
 
-  onMount(() => {
+  onMount(async () => {
     fetchCountries();
     loadCommentTemplate();
+    try {
+      const res = await fetch("/api/qrz-sync/status");
+      if (res.ok) {
+        const data = await res.json();
+        hasQrzApiKey = !!data.configured;
+      }
+    } catch {}
   });
 
   // Export filter state
@@ -736,9 +744,11 @@
           <input type="file" accept=".adi,.adif,.ADI,.ADIF" on:change={stageImportFile} disabled={importing || loadingImport || qrzImporting} />
           {loadingImport ? "Loading..." : "Choose ADIF File"}
         </label>
-        <button class="file-label qrz-import-btn" on:click={importFromQrz} disabled={importing || loadingImport || qrzImporting}>
-          {qrzImporting ? "Downloading from QRZ..." : "Import from QRZ"}
-        </button>
+        {#if hasQrzApiKey}
+          <button class="file-label qrz-import-btn" on:click={importFromQrz} disabled={importing || loadingImport || qrzImporting}>
+            {qrzImporting ? "Downloading from QRZ..." : "Import from QRZ"}
+          </button>
+        {/if}
         {#if importFileName}
           <p class="file-name">{importFileName}</p>
         {/if}

--- a/frontend/src/ExportImport.svelte
+++ b/frontend/src/ExportImport.svelte
@@ -15,8 +15,10 @@
   let qrzSyncResult = null;
   let qrzPreview = null;
   let qrzSelected = new Set();
+  let qrzFilter = "pending";
 
   $: qrzAllSelected = qrzPreview && qrzPreview.contacts && qrzPreview.contacts.length > 0 && qrzSelected.size === qrzPreview.contacts.length;
+  $: qrzExcludedCount = qrzPreview && qrzPreview.excluded ? qrzPreview.excluded.length : 0;
 
   function toggleQrzSelect(id) {
     if (qrzSelected.has(id)) {
@@ -291,13 +293,15 @@
     if (remaining === 0) importFilter = "fixed";
   }
   $: displayContacts = currentPreview && currentPreview.contacts
-    ? (activeTab === "import" && importFilter === "warnings"
-      ? currentPreview.contacts.filter(c => c.warnings && c.warnings.length > 0)
-      : activeTab === "import" && importFilter === "fixed"
-        ? currentPreview.contacts.filter(c => c._fixed)
-        : activeTab === "import" && importFilter === "merged"
-          ? currentPreview.contacts.filter(c => c.merged)
-          : currentPreview.contacts)
+    ? (activeTab === "qrz" && qrzFilter === "excluded"
+      ? (currentPreview.excluded || [])
+      : activeTab === "import" && importFilter === "warnings"
+        ? currentPreview.contacts.filter(c => c.warnings && c.warnings.length > 0)
+        : activeTab === "import" && importFilter === "fixed"
+          ? currentPreview.contacts.filter(c => c._fixed)
+          : activeTab === "import" && importFilter === "merged"
+            ? currentPreview.contacts.filter(c => c.merged)
+            : currentPreview.contacts)
     : [];
 
   const BANDS = [
@@ -550,6 +554,16 @@
   async function excludeFromQrz(contactId) {
     try {
       const res = await fetch(`/api/qrz-sync/exclude/${contactId}`, { method: "POST" });
+      if (res.ok) {
+        await fetchQrzSyncStatus();
+        expandedRow = null;
+      }
+    } catch {}
+  }
+
+  async function includeInQrz(contactId) {
+    try {
+      const res = await fetch(`/api/qrz-sync/include/${contactId}`, { method: "POST" });
       if (res.ok) {
         await fetchQrzSyncStatus();
         expandedRow = null;
@@ -824,12 +838,18 @@
           {/if}
         </div>
       {/if}
+      {#if activeTab === "qrz" && qrzPreview && qrzExcludedCount > 0}
+        <div class="filter-tabs">
+          <button class="filter-tab" class:active={qrzFilter === "pending"} on:click={() => qrzFilter = "pending"}>Pending ({qrzPreview.contacts.length})</button>
+          <button class="filter-tab" class:active={qrzFilter === "excluded"} on:click={() => qrzFilter = "excluded"}>Excluded ({qrzExcludedCount})</button>
+        </div>
+      {/if}
       {#if displayContacts.length > 0}
         <div class="preview-table-wrap">
           <table class="preview-table">
             <thead>
               <tr>
-                {#if activeTab === "qrz"}<th class="col-check"><input type="checkbox" checked={qrzAllSelected} on:click|stopPropagation={toggleQrzSelectAll} title="Select all / Deselect all" /></th>{/if}
+                {#if activeTab === "qrz" && qrzFilter === "pending"}<th class="col-check"><input type="checkbox" checked={qrzAllSelected} on:click|stopPropagation={toggleQrzSelectAll} title="Select all / Deselect all" /></th>{/if}
                 <th class="col-compact">UTC<span class="resize-handle" on:mousedown={e => startResize(e, 0)}></span></th>
                 <th class="col-compact">Call<span class="resize-handle" on:mousedown={e => startResize(e, 1)}></span></th>
                 <th class="col-comment">Comments<span class="resize-handle" on:mousedown={e => startResize(e, 2)}></span></th>
@@ -851,7 +871,7 @@
             <tbody>
               {#each displayContacts as c, i}
                 <tr class="clickable" class:expanded={expandedRow === i} class:has-warning={c.warnings && c.warnings.length > 0} class:has-merged={c.merged} on:click={() => toggleRow(i)}>
-                  {#if activeTab === "qrz"}<td class="check-cell" on:click|stopPropagation><input type="checkbox" checked={qrzSelected.has(c.id)} on:change={() => toggleQrzSelect(c.id)} /></td>{/if}
+                  {#if activeTab === "qrz" && qrzFilter === "pending"}<td class="check-cell" on:click|stopPropagation><input type="checkbox" checked={qrzSelected.has(c.id)} on:change={() => toggleQrzSelect(c.id)} /></td>{/if}
                   <td>{formatTimestamp(c.timestamp)}</td>
                   <td class="call">{c.call}</td>
                   <td class="truncate">{#if activeTab === "import" && c.original_comment && c.original_comment !== (c.comments || "")}<span class="comment-modified" title="Original: {c.original_comment}">* </span>{/if}{activeTab === "export" ? renderComment(c, commentTemplate, commentSeparator) : (c.comments || "")}</td>
@@ -872,10 +892,15 @@
                 {#if expandedRow === i}
                   <tr class="detail-row">
                     <td colspan={activeTab === "qrz" ? 17 : 16}>
-                      {#if activeTab === "qrz"}
+                      {#if activeTab === "qrz" && qrzFilter === "pending"}
                         <div class="qrz-detail-actions">
                           <button class="exclude-btn" on:click|stopPropagation={() => excludeFromQrz(c.id)}>Exclude from QRZ</button>
                           <span class="hint">Permanently skip this contact for QRZ uploads</span>
+                        </div>
+                      {:else if activeTab === "qrz" && qrzFilter === "excluded"}
+                        <div class="qrz-detail-actions">
+                          <button class="include-btn" on:click|stopPropagation={() => includeInQrz(c.id)}>Eligible for QRZ</button>
+                          <span class="hint">Make this contact eligible for QRZ uploads again</span>
                         </div>
                       {/if}
                       {#if c.warnings && c.warnings.length > 0}
@@ -949,8 +974,10 @@
         <div class="empty-preview">No file selected</div>
       {:else if activeTab === "export" && exportPreview && exportPreview.contacts.length === 0}
         <div class="empty-preview">No contacts match filters</div>
-      {:else if activeTab === "qrz" && qrzPreview && qrzPreview.contacts.length === 0}
+      {:else if activeTab === "qrz" && qrzPreview && qrzFilter === "pending" && qrzPreview.contacts.length === 0}
         <div class="empty-preview">All contacts synced to QRZ</div>
+      {:else if activeTab === "qrz" && qrzPreview && qrzFilter === "excluded" && qrzExcludedCount === 0}
+        <div class="empty-preview">No excluded contacts</div>
       {/if}
 
     </div>
@@ -1926,6 +1953,21 @@
 
   .exclude-btn:hover {
     background: var(--error, #a44);
+    color: white;
+  }
+
+  .include-btn {
+    background: var(--bg-secondary, #1a3a1a);
+    color: var(--accent, #4a4);
+    border: 1px solid var(--accent, #4a4);
+    padding: 0.25rem 0.75rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+
+  .include-btn:hover {
+    background: var(--accent, #4a4);
     color: white;
   }
 </style>

--- a/frontend/src/ExportImport.svelte
+++ b/frontend/src/ExportImport.svelte
@@ -745,6 +745,7 @@
           {loadingImport ? "Loading..." : "Choose ADIF File"}
         </label>
         {#if hasQrzApiKey}
+          <span class="or-divider">- or -</span>
           <button class="file-label qrz-import-btn" on:click={importFromQrz} disabled={importing || loadingImport || qrzImporting}>
             {qrzImporting ? "Downloading from QRZ..." : "Import from QRZ"}
           </button>
@@ -2016,5 +2017,13 @@
   .include-btn:hover {
     background: var(--accent, #4a4);
     color: white;
+  }
+
+  .or-divider {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    margin: 0.5rem 0;
+    display: block;
+    text-align: center;
   }
 </style>

--- a/frontend/src/ExportImport.svelte
+++ b/frontend/src/ExportImport.svelte
@@ -542,7 +542,7 @@
       if (statusRes.ok) qrzSyncStatus = await statusRes.json();
       if (previewRes.ok) {
         qrzPreview = await previewRes.json();
-        qrzSelected = new Set(qrzPreview.contacts.map(c => c.id));
+        qrzSelected = new Set();
       }
     } catch { qrzSyncStatus = null; qrzPreview = null; }
   }

--- a/frontend/src/ExportImport.svelte
+++ b/frontend/src/ExportImport.svelte
@@ -13,6 +13,7 @@
   let qrzSyncStatus = null;
   let qrzSyncing = false;
   let qrzSyncResult = null;
+  let qrzPreview = null;
 
   // Comment template
   const TEMPLATE_FIELDS = [
@@ -155,7 +156,7 @@
   let importFilter = "all";
 
   // Unified preview based on active tab
-  $: currentPreview = activeTab === "export" ? exportPreview : importPreview;
+  $: currentPreview = activeTab === "export" ? exportPreview : activeTab === "qrz" ? qrzPreview : importPreview;
   $: warningCount = importPreview ? (importPreview.contacts || []).filter(c => c.warnings && c.warnings.length > 0).length : 0;
   $: fixedCount = importPreview ? (importPreview.contacts || []).filter(c => c._fixed).length : 0;
   $: mergedCount = importPreview ? (importPreview.contacts || []).filter(c => c.merged).length : 0;
@@ -513,9 +514,13 @@
 
   async function fetchQrzSyncStatus() {
     try {
-      const res = await fetch("/api/qrz-sync/status");
-      if (res.ok) qrzSyncStatus = await res.json();
-    } catch { qrzSyncStatus = null; }
+      const [statusRes, previewRes] = await Promise.all([
+        fetch("/api/qrz-sync/status"),
+        fetch("/api/qrz-sync/preview"),
+      ]);
+      if (statusRes.ok) qrzSyncStatus = await statusRes.json();
+      if (previewRes.ok) qrzPreview = await previewRes.json();
+    } catch { qrzSyncStatus = null; qrzPreview = null; }
   }
 
   async function uploadToQrz(all = false) {
@@ -894,6 +899,8 @@
         <div class="empty-preview">No file selected</div>
       {:else if activeTab === "export" && exportPreview && exportPreview.contacts.length === 0}
         <div class="empty-preview">No contacts match filters</div>
+      {:else if activeTab === "qrz" && qrzPreview && qrzPreview.contacts.length === 0}
+        <div class="empty-preview">All contacts synced to QRZ</div>
       {/if}
 
     </div>

--- a/frontend/src/ExportImport.svelte
+++ b/frontend/src/ExportImport.svelte
@@ -9,6 +9,11 @@
   let message = "";
   let messageType = "";
 
+  // QRZ sync state
+  let qrzSyncStatus = null;
+  let qrzSyncing = false;
+  let qrzSyncResult = null;
+
   // Comment template
   const TEMPLATE_FIELDS = [
     { field: "skcc", label: "SKCC" },
@@ -505,12 +510,39 @@
     }
     importing = false;
   }
+
+  async function fetchQrzSyncStatus() {
+    try {
+      const res = await fetch("/api/qrz-sync/status");
+      if (res.ok) qrzSyncStatus = await res.json();
+    } catch { qrzSyncStatus = null; }
+  }
+
+  async function uploadToQrz(all = false) {
+    qrzSyncing = true;
+    qrzSyncResult = null;
+    try {
+      const endpoint = all ? "/api/qrz-sync/upload-all" : "/api/qrz-sync/upload";
+      const res = await fetch(endpoint, { method: "POST" });
+      if (res.ok) {
+        qrzSyncResult = await res.json();
+      } else {
+        const data = await res.json().catch(() => null);
+        qrzSyncResult = { error: data?.detail || `Error: ${res.status}` };
+      }
+      await fetchQrzSyncStatus();
+    } catch (e) {
+      qrzSyncResult = { error: `Network error: ${e.message}` };
+    }
+    qrzSyncing = false;
+  }
 </script>
 
 <div class="export-import">
   <div class="tab-bar">
     <button class="tab" class:active={activeTab === "import"} on:click={() => { activeTab = "import"; message = ""; }}>Import</button>
     <button class="tab" class:active={activeTab === "export"} on:click={() => { activeTab = "export"; message = ""; }}>Export</button>
+    <button class="tab" class:active={activeTab === "qrz"} on:click={() => { activeTab = "qrz"; message = ""; fetchQrzSyncStatus(); }}>QRZ Upload</button>
   </div>
 
   <div class="main-layout">
@@ -563,6 +595,45 @@
               SKCC Validated
             </label>
           </div>
+        </div>
+      {:else if activeTab === "qrz"}
+        <div class="qrz-sync-panel">
+          <h3>QRZ Logbook Upload</h3>
+          {#if qrzSyncStatus && !qrzSyncStatus.configured}
+            <p class="qrz-not-configured">QRZ Logbook API key not configured. Set it in Settings under QRZ.</p>
+          {:else if qrzSyncStatus}
+            <div class="qrz-stats">
+              <div class="stat-row"><span class="stat-label">Total contacts:</span> <span class="stat-value">{qrzSyncStatus.total}</span></div>
+              <div class="stat-row"><span class="stat-label">Synced to QRZ:</span> <span class="stat-value">{qrzSyncStatus.synced}</span></div>
+              <div class="stat-row"><span class="stat-label">Pending upload:</span> <span class="stat-value highlight">{qrzSyncStatus.pending}</span></div>
+            </div>
+            <div class="qrz-actions">
+              <button class="action-btn" on:click={() => uploadToQrz(false)} disabled={qrzSyncing || qrzSyncStatus.pending === 0}>
+                {qrzSyncing ? "Uploading..." : `Upload ${qrzSyncStatus.pending} Pending`}
+              </button>
+              <button class="action-btn secondary-btn" on:click={() => { if (confirm("Re-upload all contacts to QRZ? This will overwrite any changes made directly on QRZ.")) uploadToQrz(true); }} disabled={qrzSyncing || qrzSyncStatus.total === 0}>
+                Re-upload All
+              </button>
+            </div>
+            {#if qrzSyncResult}
+              <div class="qrz-result" class:qrz-result-error={qrzSyncResult.error || qrzSyncResult.errors > 0}>
+                {#if qrzSyncResult.error}
+                  <p>{qrzSyncResult.error}</p>
+                {:else}
+                  <p>Uploaded {qrzSyncResult.uploaded} of {qrzSyncResult.total} contacts{#if qrzSyncResult.errors > 0}, {qrzSyncResult.errors} error{qrzSyncResult.errors !== 1 ? "s" : ""}{/if}</p>
+                  {#if qrzSyncResult.error_details && qrzSyncResult.error_details.length > 0}
+                    <ul class="qrz-errors">
+                      {#each qrzSyncResult.error_details as err}
+                        <li><strong>{err.call}</strong>: {err.reason}</li>
+                      {/each}
+                    </ul>
+                  {/if}
+                {/if}
+              </div>
+            {/if}
+          {:else}
+            <p>Loading...</p>
+          {/if}
         </div>
       {:else}
         <p>Select an ADIF file to preview before importing.</p>
@@ -839,6 +910,12 @@
       <button class="action-btn" on:click={exportAdif} disabled={!exportPreview || exportPreview.included === 0}>
         Download ADIF
       </button>
+    {:else if activeTab === "qrz"}
+      <span class="action-summary">
+        {#if qrzSyncStatus && qrzSyncStatus.configured}
+          {qrzSyncStatus.pending} contact{qrzSyncStatus.pending !== 1 ? "s" : ""} pending upload to QRZ
+        {/if}
+      </span>
     {:else}
       <span class="action-summary">
         {#if importPreview}
@@ -1693,5 +1770,71 @@
     color: var(--text-muted);
     font-style: italic;
     margin-top: 0.25rem;
+  }
+
+  /* QRZ Sync panel */
+  .qrz-sync-panel h3 {
+    margin: 0 0 1rem 0;
+  }
+
+  .qrz-not-configured {
+    color: var(--text-muted);
+  }
+
+  .qrz-stats {
+    margin-bottom: 1rem;
+  }
+
+  .stat-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.25rem 0;
+  }
+
+  .stat-label {
+    color: var(--text-muted);
+  }
+
+  .stat-value.highlight {
+    color: var(--accent);
+    font-weight: bold;
+  }
+
+  .qrz-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .secondary-btn {
+    background: var(--bg-secondary, #333);
+    color: var(--text-secondary, #aaa);
+  }
+
+  .qrz-result {
+    padding: 0.75rem;
+    border-radius: 4px;
+    background: var(--bg-secondary, #1a3a1a);
+    border: 1px solid var(--accent, #4a4);
+  }
+
+  .qrz-result-error {
+    background: var(--bg-error, #3a1a1a);
+    border-color: var(--error, #a44);
+  }
+
+  .qrz-result p {
+    margin: 0;
+  }
+
+  .qrz-errors {
+    margin: 0.5rem 0 0 0;
+    padding-left: 1.5rem;
+    font-size: 0.85rem;
+  }
+
+  .qrz-errors li {
+    margin-bottom: 0.25rem;
   }
 </style>

--- a/frontend/src/ExportImport.svelte
+++ b/frontend/src/ExportImport.svelte
@@ -14,6 +14,27 @@
   let qrzSyncing = false;
   let qrzSyncResult = null;
   let qrzPreview = null;
+  let qrzSelected = new Set();
+
+  $: qrzAllSelected = qrzPreview && qrzPreview.contacts && qrzPreview.contacts.length > 0 && qrzSelected.size === qrzPreview.contacts.length;
+
+  function toggleQrzSelect(id) {
+    if (qrzSelected.has(id)) {
+      qrzSelected.delete(id);
+    } else {
+      qrzSelected.add(id);
+    }
+    qrzSelected = new Set(qrzSelected);
+  }
+
+  function toggleQrzSelectAll() {
+    if (!qrzPreview || !qrzPreview.contacts) return;
+    if (qrzAllSelected) {
+      qrzSelected = new Set();
+    } else {
+      qrzSelected = new Set(qrzPreview.contacts.map(c => c.id));
+    }
+  }
 
   // Comment template
   const TEMPLATE_FIELDS = [
@@ -519,8 +540,21 @@
         fetch("/api/qrz-sync/preview"),
       ]);
       if (statusRes.ok) qrzSyncStatus = await statusRes.json();
-      if (previewRes.ok) qrzPreview = await previewRes.json();
+      if (previewRes.ok) {
+        qrzPreview = await previewRes.json();
+        qrzSelected = new Set(qrzPreview.contacts.map(c => c.id));
+      }
     } catch { qrzSyncStatus = null; qrzPreview = null; }
+  }
+
+  async function excludeFromQrz(contactId) {
+    try {
+      const res = await fetch(`/api/qrz-sync/exclude/${contactId}`, { method: "POST" });
+      if (res.ok) {
+        await fetchQrzSyncStatus();
+        expandedRow = null;
+      }
+    } catch {}
   }
 
   async function uploadToQrz(all = false) {
@@ -528,7 +562,12 @@
     qrzSyncResult = null;
     try {
       const endpoint = all ? "/api/qrz-sync/upload-all" : "/api/qrz-sync/upload";
-      const res = await fetch(endpoint, { method: "POST" });
+      const options = { method: "POST" };
+      if (!all) {
+        options.headers = { "Content-Type": "application/json" };
+        options.body = JSON.stringify({ contact_ids: [...qrzSelected] });
+      }
+      const res = await fetch(endpoint, options);
       if (res.ok) {
         qrzSyncResult = await res.json();
       } else {
@@ -611,12 +650,15 @@
               <div class="stat-row"><span class="stat-label">Total contacts:</span> <span class="stat-value">{qrzSyncStatus.total}</span></div>
               <div class="stat-row"><span class="stat-label">Synced to QRZ:</span> <span class="stat-value">{qrzSyncStatus.synced}</span></div>
               <div class="stat-row"><span class="stat-label">Pending upload:</span> <span class="stat-value highlight">{qrzSyncStatus.pending}</span></div>
+              {#if qrzSyncStatus.excluded > 0}
+                <div class="stat-row"><span class="stat-label">Excluded:</span> <span class="stat-value">{qrzSyncStatus.excluded}</span></div>
+              {/if}
             </div>
             <div class="qrz-actions">
-              <button class="action-btn" on:click={() => uploadToQrz(false)} disabled={qrzSyncing || qrzSyncStatus.pending === 0}>
-                {qrzSyncing ? "Uploading..." : `Upload ${qrzSyncStatus.pending} Pending`}
+              <button class="action-btn" on:click={() => uploadToQrz(false)} disabled={qrzSyncing || qrzSelected.size === 0}>
+                {qrzSyncing ? "Uploading..." : `Upload ${qrzSelected.size} Selected`}
               </button>
-              <button class="action-btn secondary-btn" on:click={() => { if (confirm("Re-upload all contacts to QRZ? This will overwrite any changes made directly on QRZ.")) uploadToQrz(true); }} disabled={qrzSyncing || qrzSyncStatus.total === 0}>
+              <button class="action-btn secondary-btn" on:click={() => { if (confirm("Re-upload all non-excluded contacts to QRZ? This will overwrite any changes made directly on QRZ.")) uploadToQrz(true); }} disabled={qrzSyncing || qrzSyncStatus.total === 0}>
                 Re-upload All
               </button>
             </div>
@@ -787,6 +829,7 @@
           <table class="preview-table">
             <thead>
               <tr>
+                {#if activeTab === "qrz"}<th class="col-check"><input type="checkbox" checked={qrzAllSelected} on:click|stopPropagation={toggleQrzSelectAll} title="Select all / Deselect all" /></th>{/if}
                 <th class="col-compact">UTC<span class="resize-handle" on:mousedown={e => startResize(e, 0)}></span></th>
                 <th class="col-compact">Call<span class="resize-handle" on:mousedown={e => startResize(e, 1)}></span></th>
                 <th class="col-comment">Comments<span class="resize-handle" on:mousedown={e => startResize(e, 2)}></span></th>
@@ -808,6 +851,7 @@
             <tbody>
               {#each displayContacts as c, i}
                 <tr class="clickable" class:expanded={expandedRow === i} class:has-warning={c.warnings && c.warnings.length > 0} class:has-merged={c.merged} on:click={() => toggleRow(i)}>
+                  {#if activeTab === "qrz"}<td class="check-cell" on:click|stopPropagation><input type="checkbox" checked={qrzSelected.has(c.id)} on:change={() => toggleQrzSelect(c.id)} /></td>{/if}
                   <td>{formatTimestamp(c.timestamp)}</td>
                   <td class="call">{c.call}</td>
                   <td class="truncate">{#if activeTab === "import" && c.original_comment && c.original_comment !== (c.comments || "")}<span class="comment-modified" title="Original: {c.original_comment}">* </span>{/if}{activeTab === "export" ? renderComment(c, commentTemplate, commentSeparator) : (c.comments || "")}</td>
@@ -827,7 +871,13 @@
                 </tr>
                 {#if expandedRow === i}
                   <tr class="detail-row">
-                    <td colspan="16">
+                    <td colspan={activeTab === "qrz" ? 17 : 16}>
+                      {#if activeTab === "qrz"}
+                        <div class="qrz-detail-actions">
+                          <button class="exclude-btn" on:click|stopPropagation={() => excludeFromQrz(c.id)}>Exclude from QRZ</button>
+                          <span class="hint">Permanently skip this contact for QRZ uploads</span>
+                        </div>
+                      {/if}
                       {#if c.warnings && c.warnings.length > 0}
                         <div class="warning-list">
                           {#each c.warnings as w}
@@ -920,7 +970,8 @@
     {:else if activeTab === "qrz"}
       <span class="action-summary">
         {#if qrzSyncStatus && qrzSyncStatus.configured}
-          {qrzSyncStatus.pending} contact{qrzSyncStatus.pending !== 1 ? "s" : ""} pending upload to QRZ
+          {qrzSelected.size} of {qrzSyncStatus.pending} selected for upload
+          {#if qrzSyncStatus.excluded > 0}({qrzSyncStatus.excluded} excluded){/if}
         {/if}
       </span>
     {:else}
@@ -1843,5 +1894,38 @@
 
   .qrz-errors li {
     margin-bottom: 0.25rem;
+  }
+
+  .col-check {
+    width: 2rem;
+    text-align: center;
+  }
+
+  .check-cell {
+    text-align: center;
+  }
+
+  .qrz-detail-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--border, #555);
+  }
+
+  .exclude-btn {
+    background: var(--bg-error, #3a1a1a);
+    color: var(--error, #e66);
+    border: 1px solid var(--error, #a44);
+    padding: 0.25rem 0.75rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+  }
+
+  .exclude-btn:hover {
+    background: var(--error, #a44);
+    color: white;
   }
 </style>

--- a/frontend/src/ExportImport.svelte
+++ b/frontend/src/ExportImport.svelte
@@ -642,7 +642,7 @@
   <div class="tab-bar">
     <button class="tab" class:active={activeTab === "import"} on:click={() => { activeTab = "import"; message = ""; }}>Import</button>
     <button class="tab" class:active={activeTab === "export"} on:click={() => { activeTab = "export"; message = ""; }}>Export</button>
-    <button class="tab" class:active={activeTab === "qrz"} on:click={() => { activeTab = "qrz"; message = ""; fetchQrzSyncStatus(); }}>QRZ Upload</button>
+    {#if hasQrzApiKey}<button class="tab" class:active={activeTab === "qrz"} on:click={() => { activeTab = "qrz"; message = ""; fetchQrzSyncStatus(); }}>QRZ Upload</button>{/if}
   </div>
 
   <div class="main-layout">

--- a/frontend/src/ExportImport.svelte
+++ b/frontend/src/ExportImport.svelte
@@ -8,6 +8,7 @@
   let importing = false;
   let message = "";
   let messageType = "";
+  let qrzImporting = false;
 
   // QRZ sync state
   let qrzSyncStatus = null;
@@ -467,6 +468,38 @@
     await fetchImportPreview();
   }
 
+  async function importFromQrz() {
+    qrzImporting = true;
+    message = "";
+    try {
+      const res = await fetch("/api/qrz-sync/fetch");
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        message = data?.error || `Error: ${res.status}`;
+        messageType = "error";
+        qrzImporting = false;
+        return;
+      }
+      const data = await res.json();
+      if (data.error) {
+        message = data.error;
+        messageType = "error";
+        qrzImporting = false;
+        return;
+      }
+      // Create a synthetic File from the ADIF text and feed into the import pipeline
+      const blob = new Blob([data.adif], { type: "text/plain" });
+      importFile = new File([blob], "QRZ-logbook.adi", { type: "text/plain" });
+      importFileName = "QRZ-logbook.adi";
+      skccMarkValidated = false;
+      await fetchImportPreview();
+    } catch (e) {
+      message = `Network error: ${e.message}`;
+      messageType = "error";
+    }
+    qrzImporting = false;
+  }
+
   let suggesting = false;
 
   async function suggestTemplate() {
@@ -700,9 +733,12 @@
       {:else}
         <p>Select an ADIF file to preview before importing.</p>
         <label class="file-label">
-          <input type="file" accept=".adi,.adif,.ADI,.ADIF" on:change={stageImportFile} disabled={importing || loadingImport} />
+          <input type="file" accept=".adi,.adif,.ADI,.ADIF" on:change={stageImportFile} disabled={importing || loadingImport || qrzImporting} />
           {loadingImport ? "Loading..." : "Choose ADIF File"}
         </label>
+        <button class="file-label qrz-import-btn" on:click={importFromQrz} disabled={importing || loadingImport || qrzImporting}>
+          {qrzImporting ? "Downloading from QRZ..." : "Import from QRZ"}
+        </button>
         {#if importFileName}
           <p class="file-name">{importFileName}</p>
         {/if}

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -27,6 +27,8 @@
   let qrz_username = "";
   let qrz_password = "";
   let hasQrzPassword = false;
+  let qrz_api_key = "";
+  let hasQrzApiKey = false;
   let pota_enabled = false;
   let solar_enabled = false;
   let update_check_enabled = true;
@@ -119,6 +121,8 @@
   let global_qrz_username = "";
   let global_qrz_password = "";
   let global_hasQrzPassword = false;
+  let global_hasQrzApiKey = false;
+  let global_qrz_api_key = "";
   let global_hamalert_username = "";
   let global_hamalert_password = "";
   let global_hasHamalertPassword = false;
@@ -1374,6 +1378,23 @@
     await checkQrz();
   }
 
+  async function saveQrzApiKey() {
+    if (!qrz_api_key.trim()) return;
+    await saveSetting("qrz_api_key", qrz_api_key.trim());
+    hasQrzApiKey = true;
+    qrz_api_key = "";
+  }
+
+  async function clearQrzApiKey() {
+    await fetch("/api/settings/qrz_api_key", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value: "" }),
+    });
+    hasQrzApiKey = false;
+    qrz_api_key = "";
+  }
+
   async function loginHamalert() {
     if (!hamalert_password.trim()) return;
     await saveSetting("hamalert_password", hamalert_password.trim());
@@ -1412,6 +1433,7 @@
           // Boolean/password fields: inherit global value normally
           if (s.key === "qrz_username") { if (isGlobal) { globalPlaceholders.qrz_username = s.value; qrz_username = ""; } else qrz_username = s.value || ""; }
           if (s.key === "qrz_password") hasQrzPassword = !!s.value && s.value !== "";
+          if (s.key === "qrz_api_key") hasQrzApiKey = !!s.value && s.value !== "";
           if (s.key === "pota_enabled") pota_enabled = s.value !== "false";
           if (s.key === "solar_enabled") solar_enabled = s.value === "true";
           if (s.key === "sql_query_enabled") sql_query_enabled = s.value === "true";
@@ -1513,6 +1535,7 @@
           if (s.key === "default_rst") global_default_rst = s.value || "599";
           if (s.key === "qrz_username") global_qrz_username = s.value || "";
           if (s.key === "qrz_password") global_hasQrzPassword = !!s.value && s.value !== "";
+          if (s.key === "qrz_api_key") global_hasQrzApiKey = !!s.value && s.value !== "";
           if (s.key === "hamalert_username") global_hamalert_username = s.value || "";
           if (s.key === "hamalert_password") global_hasHamalertPassword = !!s.value && s.value !== "";
           if (s.key === "flrig_enabled") global_flrig_enabled = s.value === "true";
@@ -1795,6 +1818,15 @@
         {/if}
       </div>
     {/if}
+    <div class="setting-row">
+      <label for="rb-qrz-api-key">{hasQrzApiKey ? "Change QRZ Logbook API Key" : "QRZ Logbook API Key"}</label>
+      <input id="rb-qrz-api-key" type="text" class="secret-field" bind:value={qrz_api_key} autocomplete="new-password" data-1p-ignore data-lpignore="true" data-form-type="other" placeholder={hasQrzApiKey ? "Leave blank to keep current" : "unset"} style="min-width: 12ch" />
+    </div>
+    <div class="setting-row">
+      {#if qrz_api_key.trim()}<button type="button" class="check-now-btn" on:click={saveQrzApiKey}>Save API Key</button>{/if}
+      {#if hasQrzApiKey}<button type="button" class="check-now-btn" on:click={clearQrzApiKey}>Clear API Key</button>{/if}
+      <span class="hint">{#if hasQrzApiKey}QRZ Logbook API key is set. Upload QSOs from the Export/Import page.{:else}Get your API key from <a href="https://logbook.qrz.com/logbook" target="_blank" rel="noopener">QRZ Logbook</a> (requires XML subscription){/if}</span>
+    </div>
   </section>
 
   <section class="settings-section">
@@ -2378,6 +2410,16 @@
       {:else}
         <input id="rb-def-qrz-key" type="text" class="secret-field" bind:value={global_qrz_password} placeholder="QRZ password" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-form-type="other" style="max-width: 14rem" />
         <button class="check-now-btn" on:click={async () => { if (global_qrz_password.trim()) { await saveGlobalSetting("qrz_password", global_qrz_password.trim()); global_hasQrzPassword = true; global_qrz_password = ""; } }}>Save</button>
+      {/if}
+    </div>
+    <div class="setting-row">
+      <label>Default QRZ Logbook API Key</label>
+      {#if global_hasQrzApiKey}
+        <span class="hint">Saved</span>
+        <button class="check-now-btn" on:click={async () => { await saveGlobalSetting("qrz_api_key", ""); global_hasQrzApiKey = false; global_qrz_api_key = ""; }}>Clear</button>
+      {:else}
+        <input type="text" class="secret-field" bind:value={global_qrz_api_key} placeholder="QRZ Logbook API key" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-form-type="other" style="max-width: 14rem" />
+        <button class="check-now-btn" on:click={async () => { if (global_qrz_api_key.trim()) { await saveGlobalSetting("qrz_api_key", global_qrz_api_key.trim()); global_hasQrzApiKey = true; global_qrz_api_key = ""; } }}>Save</button>
       {/if}
     </div>
     <div class="setting-row">

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -1825,7 +1825,7 @@
     <div class="setting-row">
       {#if qrz_api_key.trim()}<button type="button" class="check-now-btn" on:click={saveQrzApiKey}>Save API Key</button>{/if}
       {#if hasQrzApiKey}<button type="button" class="check-now-btn" on:click={clearQrzApiKey}>Clear API Key</button>{/if}
-      <span class="hint">{#if hasQrzApiKey}QRZ Logbook API key is set. Upload QSOs from the Export/Import page.{:else}Get your API key from <a href="https://logbook.qrz.com/logbook" target="_blank" rel="noopener">QRZ Logbook</a> (requires XML subscription){/if}</span>
+      <span class="hint">{#if hasQrzApiKey}QRZ Logbook API key is set. Upload QSOs from the Export/Import page.{:else}Get your API key from <a href="https://logbook.qrz.com/logbook" target="_blank" rel="noopener" style="color: var(--accent)">QRZ Logbook</a> (requires XML subscription){/if}</span>
     </div>
   </section>
 

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -29,6 +29,7 @@
   let hasQrzPassword = false;
   let qrz_api_key = "";
   let hasQrzApiKey = false;
+  let qrz_auto_upload = false;
   let pota_enabled = false;
   let solar_enabled = false;
   let update_check_enabled = true;
@@ -1434,6 +1435,7 @@
           if (s.key === "qrz_username") { if (isGlobal) { globalPlaceholders.qrz_username = s.value; qrz_username = ""; } else qrz_username = s.value || ""; }
           if (s.key === "qrz_password") hasQrzPassword = !!s.value && s.value !== "";
           if (s.key === "qrz_api_key") hasQrzApiKey = !!s.value && s.value !== "";
+          if (s.key === "qrz_auto_upload") qrz_auto_upload = s.value === "true";
           if (s.key === "pota_enabled") pota_enabled = s.value !== "false";
           if (s.key === "solar_enabled") solar_enabled = s.value === "true";
           if (s.key === "sql_query_enabled") sql_query_enabled = s.value === "true";
@@ -1827,6 +1829,14 @@
       {#if hasQrzApiKey}<button type="button" class="check-now-btn" on:click={clearQrzApiKey}>Clear API Key</button>{/if}
       <span class="hint">{#if hasQrzApiKey}QRZ Logbook API key is set. Upload QSOs from the Export/Import page.{:else}Get your API key from <a href="https://logbook.qrz.com/logbook" target="_blank" rel="noopener" style="color: var(--accent)">QRZ Logbook</a> (requires XML subscription){/if}</span>
     </div>
+    {#if hasQrzApiKey}
+      <div class="setting-row toggle-row">
+        <label>
+          <input type="checkbox" bind:checked={qrz_auto_upload} on:change={() => saveSetting("qrz_auto_upload", qrz_auto_upload ? "true" : "false")} />
+          Log all QSOs to QRZ automatically
+        </label>
+      </div>
+    {/if}
   </section>
 
   <section class="settings-section">

--- a/src/rigbook/db.py
+++ b/src/rigbook/db.py
@@ -133,6 +133,7 @@ class Contact(Base):
     updated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     qrz_logid: Mapped[int | None] = mapped_column(Integer, nullable=True)
     qrz_synced_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    qrz_excluded: Mapped[int | None] = mapped_column(Integer, nullable=True, default=0)
 
 
 class Setting(Base):

--- a/src/rigbook/db.py
+++ b/src/rigbook/db.py
@@ -37,6 +37,7 @@ GLOBAL_DEFAULTABLE_KEYS = {
     "flrig_port",
     "flrig_enabled",
     "flrig_simulate",
+    "qrz_api_key",
 }
 
 # Settings that live exclusively in __global.db (not per-logbook)
@@ -130,6 +131,8 @@ class Contact(Base):
     )
     timestamp_off: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     updated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    qrz_logid: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    qrz_synced_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
 
 class Setting(Base):

--- a/src/rigbook/db.py
+++ b/src/rigbook/db.py
@@ -38,6 +38,7 @@ GLOBAL_DEFAULTABLE_KEYS = {
     "flrig_enabled",
     "flrig_simulate",
     "qrz_api_key",
+    "qrz_auto_upload",
 }
 
 # Settings that live exclusively in __global.db (not per-logbook)

--- a/src/rigbook/main.py
+++ b/src/rigbook/main.py
@@ -35,6 +35,7 @@ from rigbook.spots import start_feeds, stop_feeds
 from rigbook.routes.adif import router as adif_router
 from rigbook.routes.pota import router as pota_router
 from rigbook.routes.qrz import router as qrz_router
+from rigbook.routes.qrz_sync import router as qrz_sync_router
 from rigbook.routes.search import router as search_router
 from rigbook.routes.tiles import router as tiles_router
 from rigbook.routes.skcc import router as skcc_router
@@ -370,6 +371,7 @@ app.include_router(geo_router)
 app.include_router(adif_router)
 app.include_router(pota_router)
 app.include_router(qrz_router)
+app.include_router(qrz_sync_router)
 app.include_router(search_router)
 app.include_router(skcc_router)
 app.include_router(tiles_router)

--- a/src/rigbook/routes/adif.py
+++ b/src/rigbook/routes/adif.py
@@ -1100,6 +1100,10 @@ async def preview_import_adif(
             "updated_at": datetime.now(timezone.utc).isoformat()
             if data.get("_merged") or data.get("_skcc_auto_applied")
             else None,
+            "qrz_logid": data.get("qrz_logid"),
+            "qrz_synced_at": data.get("qrz_synced_at").isoformat()
+            if data.get("qrz_synced_at")
+            else None,
             "adif_line": record_to_adif_line(raw_record),
             "adif_lines": adif_lines,
             "warnings": warnings,
@@ -1173,6 +1177,8 @@ IMPORT_FIELDS = {
     "notes",
     "timestamp_off",
     "updated_at",
+    "qrz_logid",
+    "qrz_synced_at",
 }
 
 
@@ -1232,6 +1238,16 @@ async def import_confirmed(
                 data["updated_at"] = ua
             except (ValueError, TypeError):
                 del data["updated_at"]
+        if data.get("qrz_synced_at"):
+            try:
+                qs = data["qrz_synced_at"]
+                if isinstance(qs, str):
+                    qs = datetime.fromisoformat(qs.replace("Z", "+00:00"))
+                if qs.tzinfo is not None:
+                    qs = qs.replace(tzinfo=None)
+                data["qrz_synced_at"] = qs
+            except (ValueError, TypeError):
+                del data["qrz_synced_at"]
         # Dedup by UUID against DB and batch
         is_dup = False
         record_uuid = c.get("uuid")

--- a/src/rigbook/routes/adif.py
+++ b/src/rigbook/routes/adif.py
@@ -387,6 +387,13 @@ def adif_record_to_contact_dict(record: dict) -> dict:
     app_uuid = record.get("APP_RIGBOOK_UUID")
     if app_uuid:
         data["uuid"] = app_uuid
+    qrz_logid = record.get("APP_QRZLOG_LOGID")
+    if qrz_logid:
+        try:
+            data["qrz_logid"] = int(qrz_logid)
+            data["qrz_synced_at"] = datetime.now(timezone.utc)
+        except (ValueError, TypeError):
+            pass
     app_updated = record.get("APP_RIGBOOK_UPDATED_AT")
     if app_updated:
         try:

--- a/src/rigbook/routes/contacts.py
+++ b/src/rigbook/routes/contacts.py
@@ -324,6 +324,14 @@ async def update_contact(
     contact.updated_at = datetime.now(timezone.utc)
     await session.commit()
     await session.refresh(contact)
+
+    # Auto-upload to QRZ if enabled
+    auto_upload = await resolve_setting("qrz_auto_upload", session)
+    if auto_upload == "true":
+        api_key = await resolve_setting("qrz_api_key", session)
+        if api_key:
+            asyncio.create_task(_auto_upload_to_qrz(contact.id, api_key))
+
     return contact
 
 

--- a/src/rigbook/routes/contacts.py
+++ b/src/rigbook/routes/contacts.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from datetime import datetime, timezone
 
@@ -6,7 +7,7 @@ from pydantic import BaseModel, field_serializer, field_validator, model_validat
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from rigbook.db import Contact, get_session
+from rigbook.db import Contact, db_manager, get_session, resolve_setting
 from rigbook.normalize import normalize_contact_fields
 
 logger = logging.getLogger("rigbook")
@@ -268,8 +269,37 @@ async def create_contact(
     session.add(contact)
     await session.commit()
     await session.refresh(contact)
+
+    # Auto-upload to QRZ if enabled
+    auto_upload = await resolve_setting("qrz_auto_upload", session)
+    if auto_upload == "true":
+        api_key = await resolve_setting("qrz_api_key", session)
+        if api_key:
+            asyncio.create_task(_auto_upload_to_qrz(contact.id, api_key))
+
     return contact
 
+
+async def _auto_upload_to_qrz(contact_id: int, api_key: str):
+    """Fire-and-forget upload of a single contact to QRZ."""
+    from rigbook.routes.qrz_sync import _get_callsign, _upload_contacts
+
+    try:
+        async with db_manager._session_factory() as session:
+            contact = await session.get(Contact, contact_id)
+            if not contact:
+                return
+            callsign = await _get_callsign(session)
+            result = await _upload_contacts(
+                [contact], api_key, callsign, session, replace=False
+            )
+            logger.info(
+                "QRZ auto-upload %s: %s",
+                contact.call,
+                "ok" if result.get("uploaded") else result,
+            )
+    except Exception as e:
+        logger.warning("QRZ auto-upload failed for contact %d: %s", contact_id, e)
 
 
 @router.get("/{contact_id}", response_model=ContactResponse)

--- a/src/rigbook/routes/global_settings.py
+++ b/src/rigbook/routes/global_settings.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("rigbook")
 router = APIRouter(prefix="/api/global-settings", tags=["global-settings"])
 
 ALLOWED_KEYS = GLOBAL_DEFAULTABLE_KEYS | GLOBAL_ONLY_KEYS
-HIDDEN_KEYS = {"qrz_password", "hamalert_password"}
+HIDDEN_KEYS = {"qrz_password", "hamalert_password", "qrz_api_key"}
 
 
 class SettingValue(BaseModel):

--- a/src/rigbook/routes/qrz_sync.py
+++ b/src/rigbook/routes/qrz_sync.py
@@ -1,0 +1,233 @@
+import logging
+from datetime import datetime, timezone
+from importlib.metadata import version as pkg_version
+import httpx
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from rigbook.db import Contact, get_session, resolve_setting
+from rigbook.routes.adif import contact_to_adif_record, record_to_adif_line
+from rigbook.spots import freq_to_band
+
+logger = logging.getLogger("rigbook")
+
+router = APIRouter(prefix="/api/qrz-sync", tags=["qrz-sync"])
+
+QRZ_LOGBOOK_URL = "https://logbook.qrz.com/api"
+
+
+async def _get_api_key(session: AsyncSession) -> str | None:
+    return await resolve_setting("qrz_api_key", session)
+
+
+async def _get_callsign(session: AsyncSession) -> str | None:
+    return await resolve_setting("my_callsign", session)
+
+
+def _user_agent(callsign: str | None) -> str:
+    ver = pkg_version("rigbook")
+    if callsign:
+        return f"Rigbook/{ver} ({callsign})"
+    return f"Rigbook/{ver}"
+
+
+def _parse_qrz_response(text: str) -> dict[str, str]:
+    """Parse QRZ's ampersand-separated name=value response."""
+    result = {}
+    for pair in text.strip().split("&"):
+        if "=" in pair:
+            key, _, value = pair.partition("=")
+            result[key] = value
+    return result
+
+
+def _add_required_fields(
+    record: dict, callsign: str | None, freq_khz: str | None
+) -> dict:
+    """Add STATION_CALLSIGN and BAND fields required by QRZ."""
+    if callsign and "STATION_CALLSIGN" not in record:
+        record["STATION_CALLSIGN"] = callsign
+    if freq_khz and "BAND" not in record:
+        try:
+            band = freq_to_band(float(freq_khz))
+            if band:
+                record["BAND"] = band
+        except (ValueError, TypeError):
+            pass
+    return record
+
+
+def _needs_sync(contact: Contact) -> bool:
+    """Check if a contact needs syncing to QRZ."""
+    if contact.qrz_logid is None:
+        return True
+    if contact.updated_at and contact.qrz_synced_at:
+        return contact.updated_at > contact.qrz_synced_at
+    return False
+
+
+@router.get("/status")
+async def sync_status(session: AsyncSession = Depends(get_session)):
+    """Return count of unsynced contacts and QRZ logbook stats."""
+    api_key = await _get_api_key(session)
+    if not api_key:
+        return {"configured": False, "error": "QRZ API key not set"}
+
+    # Count contacts needing sync
+    unsynced_stmt = select(func.count(Contact.id)).where(
+        or_(
+            Contact.qrz_logid.is_(None),
+            Contact.updated_at > Contact.qrz_synced_at,
+        )
+    )
+    unsynced_count = (await session.execute(unsynced_stmt)).scalar() or 0
+
+    total_stmt = select(func.count(Contact.id))
+    total_count = (await session.execute(total_stmt)).scalar() or 0
+
+    synced_stmt = select(func.count(Contact.id)).where(
+        Contact.qrz_logid.isnot(None),
+        or_(
+            Contact.qrz_synced_at.is_(None),
+            Contact.updated_at <= Contact.qrz_synced_at,
+        ),
+    )
+    synced_count = (await session.execute(synced_stmt)).scalar() or 0
+
+    # Try to get QRZ logbook status
+    callsign = await _get_callsign(session)
+    qrz_status = None
+    try:
+        async with httpx.AsyncClient(
+            timeout=10, headers={"User-Agent": _user_agent(callsign)}
+        ) as client:
+            res = await client.post(
+                QRZ_LOGBOOK_URL,
+                data={"KEY": api_key, "ACTION": "STATUS"},
+            )
+            parsed = _parse_qrz_response(res.text)
+            if parsed.get("RESULT") == "OK":
+                qrz_status = parsed.get("DATA")
+    except Exception as e:
+        logger.warning("QRZ status check failed: %s", e)
+
+    return {
+        "configured": True,
+        "total": total_count,
+        "synced": synced_count,
+        "pending": unsynced_count,
+        "qrz_status": qrz_status,
+    }
+
+
+@router.post("/upload")
+async def upload_unsynced(session: AsyncSession = Depends(get_session)):
+    """Upload contacts that haven't been synced to QRZ yet."""
+    api_key = await _get_api_key(session)
+    if not api_key:
+        return {"error": "QRZ API key not set"}
+
+    callsign = await _get_callsign(session)
+
+    # Find contacts needing sync
+    stmt = (
+        select(Contact)
+        .where(
+            or_(
+                Contact.qrz_logid.is_(None),
+                Contact.updated_at > Contact.qrz_synced_at,
+            )
+        )
+        .order_by(Contact.timestamp.asc())
+    )
+    result = await session.execute(stmt)
+    contacts = result.scalars().all()
+
+    if not contacts:
+        return {"uploaded": 0, "errors": 0, "message": "All contacts already synced"}
+
+    return await _upload_contacts(contacts, api_key, callsign, session, replace=False)
+
+
+@router.post("/upload-all")
+async def upload_all(session: AsyncSession = Depends(get_session)):
+    """Re-upload all contacts to QRZ with REPLACE option."""
+    api_key = await _get_api_key(session)
+    if not api_key:
+        return {"error": "QRZ API key not set"}
+
+    callsign = await _get_callsign(session)
+
+    stmt = select(Contact).order_by(Contact.timestamp.asc())
+    result = await session.execute(stmt)
+    contacts = result.scalars().all()
+
+    if not contacts:
+        return {"uploaded": 0, "errors": 0, "message": "No contacts to upload"}
+
+    return await _upload_contacts(contacts, api_key, callsign, session, replace=True)
+
+
+async def _upload_contacts(
+    contacts: list[Contact],
+    api_key: str,
+    callsign: str | None,
+    session: AsyncSession,
+    replace: bool = False,
+) -> dict:
+    """Upload a list of contacts to QRZ one at a time."""
+    uploaded = 0
+    errors = 0
+    error_details = []
+    now = datetime.now(timezone.utc)
+
+    async with httpx.AsyncClient(
+        timeout=15, headers={"User-Agent": _user_agent(callsign)}
+    ) as client:
+        for contact in contacts:
+            record = contact_to_adif_record(contact)
+            record = _add_required_fields(record, callsign, contact.freq)
+            adif_line = record_to_adif_line(record)
+
+            data = {
+                "KEY": api_key,
+                "ACTION": "INSERT",
+                "ADIF": adif_line,
+            }
+            if replace:
+                data["OPTION"] = "REPLACE"
+
+            try:
+                res = await client.post(QRZ_LOGBOOK_URL, data=data)
+                parsed = _parse_qrz_response(res.text)
+
+                if parsed.get("RESULT") == "OK" or parsed.get("RESULT") == "REPLACE":
+                    logid = parsed.get("LOGID")
+                    if logid:
+                        contact.qrz_logid = int(logid)
+                    contact.qrz_synced_at = now
+                    uploaded += 1
+                elif parsed.get("RESULT") == "FAIL":
+                    reason = parsed.get("REASON", "Unknown error")
+                    errors += 1
+                    error_details.append({"call": contact.call, "reason": reason})
+                    logger.warning("QRZ upload failed for %s: %s", contact.call, reason)
+                else:
+                    errors += 1
+                    error_details.append(
+                        {"call": contact.call, "reason": res.text[:200]}
+                    )
+            except Exception as e:
+                errors += 1
+                error_details.append({"call": contact.call, "reason": str(e)})
+                logger.warning("QRZ upload error for %s: %s", contact.call, e)
+
+    await session.commit()
+
+    return {
+        "uploaded": uploaded,
+        "errors": errors,
+        "total": len(contacts),
+        "error_details": error_details[:20],
+    }

--- a/src/rigbook/routes/qrz_sync.py
+++ b/src/rigbook/routes/qrz_sync.py
@@ -221,6 +221,63 @@ async def upload_all(session: AsyncSession = Depends(get_session)):
     return await _upload_contacts(contacts, api_key, callsign, session, replace=True)
 
 
+@router.get("/fetch")
+async def fetch_qrz_logbook(session: AsyncSession = Depends(get_session)):
+    """Fetch entire QRZ logbook as ADIF text, paginating with MAX/AFTERLOGID."""
+    api_key = await _get_api_key(session)
+    if not api_key:
+        return {"error": "QRZ API key not set"}
+
+    callsign = await _get_callsign(session)
+    all_adif = []
+    after_logid = 0
+    page_size = 250
+
+    async with httpx.AsyncClient(
+        timeout=30, headers={"User-Agent": _user_agent(callsign)}
+    ) as client:
+        while True:
+            res = await client.post(
+                QRZ_LOGBOOK_URL,
+                data={
+                    "KEY": api_key,
+                    "ACTION": "FETCH",
+                    "OPTION": f"TYPE:ADIF,MAX:{page_size},AFTERLOGID:{after_logid}",
+                },
+            )
+            parsed = _parse_qrz_response(res.text)
+
+            if parsed.get("RESULT") != "OK":
+                reason = parsed.get("REASON", "Unknown error")
+                if all_adif:
+                    break
+                return {"error": f"QRZ fetch failed: {reason}"}
+
+            adif_data = parsed.get("ADIF", "")
+            if not adif_data:
+                break
+
+            all_adif.append(adif_data)
+
+            count = int(parsed.get("COUNT", "0"))
+            if count < page_size:
+                break
+
+            # Find highest app_qrzlog_logid for pagination
+            import re
+
+            logids = re.findall(
+                r"<app_qrzlog_logid:\d+>(\d+)", adif_data, re.IGNORECASE
+            )
+            if logids:
+                after_logid = max(int(lid) for lid in logids) + 1
+            else:
+                break
+
+    adif_text = "\n".join(all_adif)
+    return {"adif": adif_text, "ok": True}
+
+
 @router.post("/exclude/{contact_id}")
 async def exclude_contact(
     contact_id: int, session: AsyncSession = Depends(get_session)

--- a/src/rigbook/routes/qrz_sync.py
+++ b/src/rigbook/routes/qrz_sync.py
@@ -151,9 +151,23 @@ async def sync_preview(session: AsyncSession = Depends(get_session)):
         data = ContactResponse.model_validate(c).model_dump()
         previews.append(data)
 
+    excluded_stmt = (
+        select(Contact)
+        .where(Contact.qrz_excluded == 1)
+        .order_by(Contact.timestamp.desc())
+    )
+    excluded_result = await session.execute(excluded_stmt)
+    excluded_contacts = excluded_result.scalars().all()
+
+    excluded_previews = []
+    for c in excluded_contacts:
+        data = ContactResponse.model_validate(c).model_dump()
+        excluded_previews.append(data)
+
     return {
         "configured": True,
         "contacts": previews,
+        "excluded": excluded_previews,
         "pending": len(previews),
         "total": total_count,
     }

--- a/src/rigbook/routes/qrz_sync.py
+++ b/src/rigbook/routes/qrz_sync.py
@@ -322,6 +322,12 @@ async def fetch_qrz_logbook(session: AsyncSession = Depends(get_session)):
                 logger.info("QRZ FETCH page %d: empty ADIF, done", page_num)
                 break
 
+            logger.info(
+                "QRZ FETCH page %d ADIF preview: %s",
+                page_num,
+                repr(adif_data[:500]),
+            )
+
             # Count <eor> markers to verify record count
             eor_count = len(re.findall(r"<eor>", adif_data, re.IGNORECASE))
             logger.info(

--- a/src/rigbook/routes/qrz_sync.py
+++ b/src/rigbook/routes/qrz_sync.py
@@ -283,7 +283,7 @@ async def _upload_contacts(
                 "ACTION": "INSERT",
                 "ADIF": adif_line,
             }
-            if replace:
+            if replace or contact.qrz_logid is not None:
                 data["OPTION"] = "REPLACE"
 
             try:

--- a/src/rigbook/routes/qrz_sync.py
+++ b/src/rigbook/routes/qrz_sync.py
@@ -1,3 +1,4 @@
+import html
 import logging
 import re
 from datetime import datetime, timezone
@@ -296,7 +297,7 @@ async def fetch_qrz_logbook(session: AsyncSession = Depends(get_session)):
             parsed = _parse_qrz_response(raw_text)
             result_code = parsed.get("RESULT", "(missing)")
             count_str = parsed.get("COUNT", "0")
-            adif_data = parsed.get("ADIF", "")
+            adif_data = html.unescape(parsed.get("ADIF", ""))
 
             logger.info(
                 "QRZ FETCH page %d: RESULT=%s, COUNT=%s, ADIF length=%d chars",

--- a/src/rigbook/routes/qrz_sync.py
+++ b/src/rigbook/routes/qrz_sync.py
@@ -1,8 +1,10 @@
 import logging
 from datetime import datetime, timezone
 from importlib.metadata import version as pkg_version
+
 import httpx
 from fastapi import APIRouter, Depends
+from pydantic import BaseModel
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,6 +18,18 @@ logger = logging.getLogger("rigbook")
 router = APIRouter(prefix="/api/qrz-sync", tags=["qrz-sync"])
 
 QRZ_LOGBOOK_URL = "https://logbook.qrz.com/api"
+
+# Common filter: not excluded from QRZ
+_not_excluded = or_(Contact.qrz_excluded.is_(None), Contact.qrz_excluded == 0)
+
+# Common filter: needs sync (new or updated since last sync) and not excluded
+_needs_sync = (
+    _not_excluded,
+    or_(
+        Contact.qrz_logid.is_(None),
+        Contact.updated_at > Contact.qrz_synced_at,
+    ),
+)
 
 
 async def _get_api_key(session: AsyncSession) -> str | None:
@@ -59,15 +73,6 @@ def _add_required_fields(
     return record
 
 
-def _needs_sync(contact: Contact) -> bool:
-    """Check if a contact needs syncing to QRZ."""
-    if contact.qrz_logid is None:
-        return True
-    if contact.updated_at and contact.qrz_synced_at:
-        return contact.updated_at > contact.qrz_synced_at
-    return False
-
-
 @router.get("/status")
 async def sync_status(session: AsyncSession = Depends(get_session)):
     """Return count of unsynced contacts and QRZ logbook stats."""
@@ -75,19 +80,20 @@ async def sync_status(session: AsyncSession = Depends(get_session)):
     if not api_key:
         return {"configured": False, "error": "QRZ API key not set"}
 
-    # Count contacts needing sync
-    unsynced_stmt = select(func.count(Contact.id)).where(
-        or_(
-            Contact.qrz_logid.is_(None),
-            Contact.updated_at > Contact.qrz_synced_at,
-        )
-    )
-    unsynced_count = (await session.execute(unsynced_stmt)).scalar() or 0
+    unsynced_count = (
+        await session.execute(select(func.count(Contact.id)).where(*_needs_sync))
+    ).scalar() or 0
 
-    total_stmt = select(func.count(Contact.id))
-    total_count = (await session.execute(total_stmt)).scalar() or 0
+    total_count = (await session.execute(select(func.count(Contact.id)))).scalar() or 0
+
+    excluded_count = (
+        await session.execute(
+            select(func.count(Contact.id)).where(Contact.qrz_excluded == 1)
+        )
+    ).scalar() or 0
 
     synced_stmt = select(func.count(Contact.id)).where(
+        _not_excluded,
         Contact.qrz_logid.isnot(None),
         or_(
             Contact.qrz_synced_at.is_(None),
@@ -118,29 +124,21 @@ async def sync_status(session: AsyncSession = Depends(get_session)):
         "total": total_count,
         "synced": synced_count,
         "pending": unsynced_count,
+        "excluded": excluded_count,
         "qrz_status": qrz_status,
     }
 
 
 @router.get("/preview")
 async def sync_preview(session: AsyncSession = Depends(get_session)):
-    """Return contacts pending upload to QRZ, in the same format as export preview."""
+    """Return contacts pending upload to QRZ."""
     api_key = await _get_api_key(session)
     if not api_key:
         return {"configured": False, "contacts": [], "pending": 0, "total": 0}
 
     total_count = (await session.execute(select(func.count(Contact.id)))).scalar() or 0
 
-    stmt = (
-        select(Contact)
-        .where(
-            or_(
-                Contact.qrz_logid.is_(None),
-                Contact.updated_at > Contact.qrz_synced_at,
-            )
-        )
-        .order_by(Contact.timestamp.desc())
-    )
+    stmt = select(Contact).where(*_needs_sync).order_by(Contact.timestamp.desc())
     result = await session.execute(stmt)
     contacts = result.scalars().all()
 
@@ -157,31 +155,31 @@ async def sync_preview(session: AsyncSession = Depends(get_session)):
     }
 
 
+class UploadRequest(BaseModel):
+    contact_ids: list[int]
+
+
 @router.post("/upload")
-async def upload_unsynced(session: AsyncSession = Depends(get_session)):
-    """Upload contacts that haven't been synced to QRZ yet."""
+async def upload_selected(
+    body: UploadRequest, session: AsyncSession = Depends(get_session)
+):
+    """Upload selected contacts to QRZ."""
     api_key = await _get_api_key(session)
     if not api_key:
         return {"error": "QRZ API key not set"}
 
     callsign = await _get_callsign(session)
 
-    # Find contacts needing sync
     stmt = (
         select(Contact)
-        .where(
-            or_(
-                Contact.qrz_logid.is_(None),
-                Contact.updated_at > Contact.qrz_synced_at,
-            )
-        )
+        .where(Contact.id.in_(body.contact_ids), _not_excluded)
         .order_by(Contact.timestamp.asc())
     )
     result = await session.execute(stmt)
     contacts = result.scalars().all()
 
     if not contacts:
-        return {"uploaded": 0, "errors": 0, "message": "All contacts already synced"}
+        return {"uploaded": 0, "errors": 0, "message": "No contacts to upload"}
 
     return await _upload_contacts(contacts, api_key, callsign, session, replace=False)
 
@@ -195,7 +193,7 @@ async def upload_all(session: AsyncSession = Depends(get_session)):
 
     callsign = await _get_callsign(session)
 
-    stmt = select(Contact).order_by(Contact.timestamp.asc())
+    stmt = select(Contact).where(_not_excluded).order_by(Contact.timestamp.asc())
     result = await session.execute(stmt)
     contacts = result.scalars().all()
 
@@ -203,6 +201,36 @@ async def upload_all(session: AsyncSession = Depends(get_session)):
         return {"uploaded": 0, "errors": 0, "message": "No contacts to upload"}
 
     return await _upload_contacts(contacts, api_key, callsign, session, replace=True)
+
+
+@router.post("/exclude/{contact_id}")
+async def exclude_contact(
+    contact_id: int, session: AsyncSession = Depends(get_session)
+):
+    """Mark a contact as excluded from QRZ uploads."""
+    contact = (
+        await session.execute(select(Contact).where(Contact.id == contact_id))
+    ).scalar_one_or_none()
+    if not contact:
+        return {"error": "Contact not found"}
+    contact.qrz_excluded = 1
+    await session.commit()
+    return {"ok": True, "id": contact_id}
+
+
+@router.post("/include/{contact_id}")
+async def include_contact(
+    contact_id: int, session: AsyncSession = Depends(get_session)
+):
+    """Remove exclusion flag from a contact."""
+    contact = (
+        await session.execute(select(Contact).where(Contact.id == contact_id))
+    ).scalar_one_or_none()
+    if not contact:
+        return {"error": "Contact not found"}
+    contact.qrz_excluded = 0
+    await session.commit()
+    return {"ok": True, "id": contact_id}
 
 
 async def _upload_contacts(

--- a/src/rigbook/routes/qrz_sync.py
+++ b/src/rigbook/routes/qrz_sync.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from rigbook.db import Contact, get_session, resolve_setting
 from rigbook.routes.adif import contact_to_adif_record, record_to_adif_line
+from rigbook.routes.contacts import ContactResponse
 from rigbook.spots import freq_to_band
 
 logger = logging.getLogger("rigbook")
@@ -118,6 +119,41 @@ async def sync_status(session: AsyncSession = Depends(get_session)):
         "synced": synced_count,
         "pending": unsynced_count,
         "qrz_status": qrz_status,
+    }
+
+
+@router.get("/preview")
+async def sync_preview(session: AsyncSession = Depends(get_session)):
+    """Return contacts pending upload to QRZ, in the same format as export preview."""
+    api_key = await _get_api_key(session)
+    if not api_key:
+        return {"configured": False, "contacts": [], "pending": 0, "total": 0}
+
+    total_count = (await session.execute(select(func.count(Contact.id)))).scalar() or 0
+
+    stmt = (
+        select(Contact)
+        .where(
+            or_(
+                Contact.qrz_logid.is_(None),
+                Contact.updated_at > Contact.qrz_synced_at,
+            )
+        )
+        .order_by(Contact.timestamp.desc())
+    )
+    result = await session.execute(stmt)
+    contacts = result.scalars().all()
+
+    previews = []
+    for c in contacts:
+        data = ContactResponse.model_validate(c).model_dump()
+        previews.append(data)
+
+    return {
+        "configured": True,
+        "contacts": previews,
+        "pending": len(previews),
+        "total": total_count,
     }
 
 

--- a/src/rigbook/routes/qrz_sync.py
+++ b/src/rigbook/routes/qrz_sync.py
@@ -52,9 +52,27 @@ def _user_agent(callsign: str | None) -> str:
 
 
 def _parse_qrz_response(text: str) -> dict[str, str]:
-    """Parse QRZ's ampersand-separated name=value response."""
+    """Parse QRZ's ampersand-separated name=value response.
+
+    The ADIF field contains raw ADIF data that may include '&' characters,
+    so we extract it separately before splitting the rest.
+    """
     result = {}
-    for pair in text.strip().split("&"):
+    body = text.strip()
+
+    # ADIF field is always last and can contain '&', so extract it first
+    adif_marker = "&ADIF="
+    idx = body.find(adif_marker)
+    if idx == -1:
+        # Also check if response starts with ADIF=
+        if body.startswith("ADIF="):
+            result["ADIF"] = body[5:]
+            return result
+    else:
+        result["ADIF"] = body[idx + len(adif_marker) :]
+        body = body[:idx]
+
+    for pair in body.split("&"):
         if "=" in pair:
             key, _, value = pair.partition("=")
             result[key] = value

--- a/src/rigbook/routes/qrz_sync.py
+++ b/src/rigbook/routes/qrz_sync.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from datetime import datetime, timezone
 from importlib.metadata import version as pkg_version
 
@@ -128,6 +129,7 @@ async def sync_status(session: AsyncSession = Depends(get_session)):
     callsign = await _get_callsign(session)
     qrz_status = None
     try:
+        logger.info("QRZ STATUS request")
         async with httpx.AsyncClient(
             timeout=10, headers={"User-Agent": _user_agent(callsign)}
         ) as client:
@@ -136,10 +138,19 @@ async def sync_status(session: AsyncSession = Depends(get_session)):
                 data={"KEY": api_key, "ACTION": "STATUS"},
             )
             parsed = _parse_qrz_response(res.text)
+            logger.info("QRZ STATUS response: RESULT=%s", parsed.get("RESULT"))
             if parsed.get("RESULT") == "OK":
                 qrz_status = parsed.get("DATA")
     except Exception as e:
-        logger.warning("QRZ status check failed: %s", e)
+        logger.warning("QRZ STATUS failed: %s", e)
+
+    logger.info(
+        "QRZ sync status: total=%d, synced=%d, pending=%d, excluded=%d",
+        total_count,
+        synced_count,
+        unsynced_count,
+        excluded_count,
+    )
 
     return {
         "configured": True,
@@ -205,6 +216,7 @@ async def upload_selected(
         return {"error": "QRZ API key not set"}
 
     callsign = await _get_callsign(session)
+    logger.info("QRZ upload requested for %d contact IDs", len(body.contact_ids))
 
     stmt = (
         select(Contact)
@@ -215,6 +227,7 @@ async def upload_selected(
     contacts = result.scalars().all()
 
     if not contacts:
+        logger.info("QRZ upload: no eligible contacts found")
         return {"uploaded": 0, "errors": 0, "message": "No contacts to upload"}
 
     return await _upload_contacts(contacts, api_key, callsign, session, replace=False)
@@ -236,6 +249,7 @@ async def upload_all(session: AsyncSession = Depends(get_session)):
     if not contacts:
         return {"uploaded": 0, "errors": 0, "message": "No contacts to upload"}
 
+    logger.info("QRZ upload-all: %d contacts", len(contacts))
     return await _upload_contacts(contacts, api_key, callsign, session, replace=True)
 
 
@@ -250,49 +264,110 @@ async def fetch_qrz_logbook(session: AsyncSession = Depends(get_session)):
     all_adif = []
     after_logid = 0
     page_size = 250
+    total_records = 0
+    page_num = 0
+
+    logger.info("QRZ FETCH: starting logbook download")
 
     async with httpx.AsyncClient(
         timeout=30, headers={"User-Agent": _user_agent(callsign)}
     ) as client:
         while True:
+            page_num += 1
+            option = f"TYPE:ADIF,MAX:{page_size},AFTERLOGID:{after_logid}"
+            logger.info("QRZ FETCH page %d: OPTION=%s", page_num, option)
+
             res = await client.post(
                 QRZ_LOGBOOK_URL,
                 data={
                     "KEY": api_key,
                     "ACTION": "FETCH",
-                    "OPTION": f"TYPE:ADIF,MAX:{page_size},AFTERLOGID:{after_logid}",
+                    "OPTION": option,
                 },
             )
-            parsed = _parse_qrz_response(res.text)
 
-            if parsed.get("RESULT") != "OK":
+            raw_text = res.text
+            logger.debug(
+                "QRZ FETCH raw response (%d chars): %s",
+                len(raw_text),
+                raw_text[:500],
+            )
+
+            parsed = _parse_qrz_response(raw_text)
+            result_code = parsed.get("RESULT", "(missing)")
+            count_str = parsed.get("COUNT", "0")
+            adif_data = parsed.get("ADIF", "")
+
+            logger.info(
+                "QRZ FETCH page %d: RESULT=%s, COUNT=%s, ADIF length=%d chars",
+                page_num,
+                result_code,
+                count_str,
+                len(adif_data),
+            )
+
+            if result_code != "OK":
                 reason = parsed.get("REASON", "Unknown error")
+                logger.warning(
+                    "QRZ FETCH page %d failed: %s (all parsed keys: %s)",
+                    page_num,
+                    reason,
+                    list(parsed.keys()),
+                )
                 if all_adif:
                     break
                 return {"error": f"QRZ fetch failed: {reason}"}
 
-            adif_data = parsed.get("ADIF", "")
             if not adif_data:
+                logger.info("QRZ FETCH page %d: empty ADIF, done", page_num)
                 break
 
-            all_adif.append(adif_data)
+            # Count <eor> markers to verify record count
+            eor_count = len(re.findall(r"<eor>", adif_data, re.IGNORECASE))
+            logger.info(
+                "QRZ FETCH page %d: %d <eor> markers found in ADIF",
+                page_num,
+                eor_count,
+            )
+            if eor_count > 0:
+                # Log first record as sample
+                first_eor = re.search(r"<eor>", adif_data, re.IGNORECASE)
+                if first_eor:
+                    logger.debug(
+                        "QRZ FETCH sample record: %s",
+                        adif_data[: first_eor.end()],
+                    )
 
-            count = int(parsed.get("COUNT", "0"))
+            all_adif.append(adif_data)
+            total_records += eor_count
+
+            count = int(count_str)
             if count < page_size:
+                logger.info(
+                    "QRZ FETCH: last page (count %d < page_size %d)",
+                    count,
+                    page_size,
+                )
                 break
 
             # Find highest app_qrzlog_logid for pagination
-            import re
-
             logids = re.findall(
                 r"<app_qrzlog_logid:\d+>(\d+)", adif_data, re.IGNORECASE
             )
             if logids:
                 after_logid = max(int(lid) for lid in logids) + 1
+                logger.info("QRZ FETCH: next AFTERLOGID=%d", after_logid)
             else:
+                logger.info("QRZ FETCH: no app_qrzlog_logid found, stopping")
                 break
 
     adif_text = "\n".join(all_adif)
+    logger.info(
+        "QRZ FETCH complete: %d pages, %d records, %d chars total ADIF",
+        page_num,
+        total_records,
+        len(adif_text),
+    )
     return {"adif": adif_text, "ok": True}
 
 
@@ -308,6 +383,7 @@ async def exclude_contact(
         return {"error": "Contact not found"}
     contact.qrz_excluded = 1
     await session.commit()
+    logger.info("QRZ excluded contact %d (%s)", contact_id, contact.call)
     return {"ok": True, "id": contact_id}
 
 
@@ -323,6 +399,7 @@ async def include_contact(
         return {"error": "Contact not found"}
     contact.qrz_excluded = 0
     await session.commit()
+    logger.info("QRZ included contact %d (%s)", contact_id, contact.call)
     return {"ok": True, "id": contact_id}
 
 
@@ -341,6 +418,10 @@ async def _upload_contacts(
 
     comment_template, comment_separator = await _fetch_comment_settings(session)
 
+    logger.info(
+        "QRZ INSERT: uploading %d contacts (replace=%s)", len(contacts), replace
+    )
+
     async with httpx.AsyncClient(
         timeout=15, headers={"User-Agent": _user_agent(callsign)}
     ) as client:
@@ -353,40 +434,68 @@ async def _upload_contacts(
             record = _add_required_fields(record, callsign, contact.freq)
             adif_line = record_to_adif_line(record)
 
+            use_replace = replace or contact.qrz_logid is not None
             data = {
                 "KEY": api_key,
                 "ACTION": "INSERT",
                 "ADIF": adif_line,
             }
-            if replace or contact.qrz_logid is not None:
+            if use_replace:
                 data["OPTION"] = "REPLACE"
+
+            logger.debug(
+                "QRZ INSERT %s: ADIF=%s, REPLACE=%s",
+                contact.call,
+                adif_line[:200],
+                use_replace,
+            )
 
             try:
                 res = await client.post(QRZ_LOGBOOK_URL, data=data)
                 parsed = _parse_qrz_response(res.text)
+                result_code = parsed.get("RESULT", "(missing)")
 
-                if parsed.get("RESULT") == "OK" or parsed.get("RESULT") == "REPLACE":
+                logger.info(
+                    "QRZ INSERT %s: RESULT=%s, LOGID=%s",
+                    contact.call,
+                    result_code,
+                    parsed.get("LOGID", "(none)"),
+                )
+
+                if result_code in ("OK", "REPLACE"):
                     logid = parsed.get("LOGID")
                     if logid:
                         contact.qrz_logid = int(logid)
                     contact.qrz_synced_at = now
                     uploaded += 1
-                elif parsed.get("RESULT") == "FAIL":
+                elif result_code == "FAIL":
                     reason = parsed.get("REASON", "Unknown error")
                     errors += 1
                     error_details.append({"call": contact.call, "reason": reason})
-                    logger.warning("QRZ upload failed for %s: %s", contact.call, reason)
+                    logger.warning("QRZ INSERT %s failed: %s", contact.call, reason)
                 else:
                     errors += 1
                     error_details.append(
                         {"call": contact.call, "reason": res.text[:200]}
                     )
+                    logger.warning(
+                        "QRZ INSERT %s unexpected response: %s",
+                        contact.call,
+                        res.text[:200],
+                    )
             except Exception as e:
                 errors += 1
                 error_details.append({"call": contact.call, "reason": str(e)})
-                logger.warning("QRZ upload error for %s: %s", contact.call, e)
+                logger.warning("QRZ INSERT %s error: %s", contact.call, e)
 
     await session.commit()
+
+    logger.info(
+        "QRZ INSERT complete: %d uploaded, %d errors, %d total",
+        uploaded,
+        errors,
+        len(contacts),
+    )
 
     return {
         "uploaded": uploaded,

--- a/src/rigbook/routes/qrz_sync.py
+++ b/src/rigbook/routes/qrz_sync.py
@@ -9,7 +9,11 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from rigbook.db import Contact, get_session, resolve_setting
-from rigbook.routes.adif import contact_to_adif_record, record_to_adif_line
+from rigbook.routes.adif import (
+    _fetch_comment_settings,
+    contact_to_adif_record,
+    record_to_adif_line,
+)
 from rigbook.routes.contacts import ContactResponse
 from rigbook.spots import freq_to_band
 
@@ -246,11 +250,17 @@ async def _upload_contacts(
     error_details = []
     now = datetime.now(timezone.utc)
 
+    comment_template, comment_separator = await _fetch_comment_settings(session)
+
     async with httpx.AsyncClient(
         timeout=15, headers={"User-Agent": _user_agent(callsign)}
     ) as client:
         for contact in contacts:
-            record = contact_to_adif_record(contact)
+            record = contact_to_adif_record(
+                contact,
+                comment_template=comment_template or None,
+                comment_separator=comment_separator,
+            )
             record = _add_required_fields(record, callsign, contact.freq)
             adif_line = record_to_adif_line(record)
 

--- a/src/rigbook/routes/settings.py
+++ b/src/rigbook/routes/settings.py
@@ -36,7 +36,7 @@ class SettingResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
-HIDDEN_KEYS = {"qrz_password", "hamalert_password"}
+HIDDEN_KEYS = {"qrz_password", "hamalert_password", "qrz_api_key"}
 
 
 def _redact(setting: Setting, source: str = "logbook") -> SettingResponse:


### PR DESCRIPTION
## Summary
- Upload QSOs to QRZ via the Logbook API with per-row selection, exclude/include, and re-upload all
- Import contacts from QRZ logbook directly (Import tab → Import from QRZ button)
- Auto-upload new and edited QSOs to QRZ when enabled in settings
- QRZ sync tracking: `qrz_logid`, `qrz_synced_at`, `qrz_excluded` columns on contacts
- Comment template applied to QRZ uploads matching ADIF export behavior
- Comprehensive logging for all QRZ API interactions
- Settings: QRZ Logbook API Key (per-logbook and global), auto-upload toggle
- UI: QRZ Upload tab with pending/excluded views, preview table, and status summary

Closes #166