### PR TITLE
Add default host setting to Network settings

### DIFF
--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -132,6 +132,7 @@
   let global_flrig_host = "127.0.0.1";
   let global_flrig_port = "12345";
   let global_default_pick_mode = true;
+  let global_default_host = "127.0.0.1";
   let global_default_port = "8073";
   let global_default_logbook_name = "rigbook";
   let global_open_browser_on_startup = true;
@@ -1545,6 +1546,7 @@
           if (s.key === "flrig_host") global_flrig_host = s.value || "127.0.0.1";
           if (s.key === "flrig_port") global_flrig_port = s.value || "12345";
           if (s.key === "default_pick_mode") global_default_pick_mode = s.value !== "false";
+          if (s.key === "default_host") global_default_host = s.value || "127.0.0.1";
           if (s.key === "default_port") global_default_port = s.value || "8073";
           if (s.key === "default_logbook_name") global_default_logbook_name = s.value || "rigbook";
           if (s.key === "open_browser_on_startup") global_open_browser_on_startup = s.value !== "false";
@@ -2497,6 +2499,11 @@
 
   <section class="settings-section">
     <h3>Network</h3>
+    <div class="setting-row">
+      <label for="global_default_host">Default Host</label>
+      <input id="global_default_host" type="text" bind:value={global_default_host} on:blur={() => saveGlobalSetting("default_host", global_default_host.trim())} autocomplete="off" style="max-width: 10rem" />
+      <span class="hint">Bind address. Use <code>0.0.0.0</code> to listen on all interfaces. Override with <code>RIGBOOK_HOST</code> env var.</span>
+    </div>
     <div class="setting-row">
       <label for="global_default_port">Default Port</label>
       <input id="global_default_port" type="text" bind:value={global_default_port} on:blur={() => saveGlobalSetting("default_port", global_default_port.trim())} autocomplete="off" style="max-width: 6rem" />

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2502,10 +2502,12 @@
     <span class="hint">Changing these settings requires restarting rigbook.</span>
     <div class="setting-row">
       <label for="global_default_host">Default Host</label>
-      <input id="global_default_host" type="text" bind:value={global_default_host} on:blur={() => saveGlobalSetting("default_host", global_default_host.trim())} autocomplete="off" style="max-width: 10rem" />
-      {#if global_default_host.trim() !== "127.0.0.1"}
-        <button type="button" class="btn btn-sm" on:click={() => { global_default_host = "127.0.0.1"; saveGlobalSetting("default_host", "127.0.0.1"); }}>Reset</button>
-      {/if}
+      <span style="display: inline-flex; align-items: center; gap: 0.5rem;">
+        <input id="global_default_host" type="text" bind:value={global_default_host} on:blur={() => saveGlobalSetting("default_host", global_default_host.trim())} autocomplete="off" style="max-width: 10rem" />
+        {#if global_default_host.trim() !== "127.0.0.1"}
+          <button type="button" class="btn btn-sm" on:click={() => { global_default_host = "127.0.0.1"; saveGlobalSetting("default_host", "127.0.0.1"); }}>Reset</button>
+        {/if}
+      </span>
       <span class="hint">Bind address. Use <code>0.0.0.0</code> to listen on all interfaces. Override with <code>RIGBOOK_HOST</code> env var.</span>
       {#if global_default_host.trim() && global_default_host.trim() !== "127.0.0.1"}
         <span class="hint" style="color: var(--warning-color, #e6a700); font-weight: bold;">⚠ Warning: rigbook has no authentication. Serving on a public network is not recommended.</span>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2503,6 +2503,9 @@
       <label for="global_default_host">Default Host</label>
       <input id="global_default_host" type="text" bind:value={global_default_host} on:blur={() => saveGlobalSetting("default_host", global_default_host.trim())} autocomplete="off" style="max-width: 10rem" />
       <span class="hint">Bind address. Use <code>0.0.0.0</code> to listen on all interfaces. Override with <code>RIGBOOK_HOST</code> env var.</span>
+      {#if global_default_host.trim() && global_default_host.trim() !== "127.0.0.1"}
+        <span class="hint" style="color: var(--warning-color, #e6a700); font-weight: bold;">⚠ Warning: rigbook has no authentication. Serving on a public network is not recommended.</span>
+      {/if}
     </div>
     <div class="setting-row">
       <label for="global_default_port">Default Port</label>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2499,6 +2499,7 @@
 
   <section class="settings-section">
     <h3>Network</h3>
+    <span class="hint">These settings require restarting rigbook.</span>
     <div class="setting-row">
       <label for="global_default_host">Default Host</label>
       <input id="global_default_host" type="text" bind:value={global_default_host} on:blur={() => saveGlobalSetting("default_host", global_default_host.trim())} autocomplete="off" style="max-width: 10rem" />

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2503,6 +2503,9 @@
     <div class="setting-row">
       <label for="global_default_host">Default Host</label>
       <input id="global_default_host" type="text" bind:value={global_default_host} on:blur={() => saveGlobalSetting("default_host", global_default_host.trim())} autocomplete="off" style="max-width: 10rem" />
+      {#if global_default_host.trim() !== "127.0.0.1"}
+        <button type="button" class="btn btn-sm" on:click={() => { global_default_host = "127.0.0.1"; saveGlobalSetting("default_host", "127.0.0.1"); }}>Reset</button>
+      {/if}
       <span class="hint">Bind address. Use <code>0.0.0.0</code> to listen on all interfaces. Override with <code>RIGBOOK_HOST</code> env var.</span>
       {#if global_default_host.trim() && global_default_host.trim() !== "127.0.0.1"}
         <span class="hint" style="color: var(--warning-color, #e6a700); font-weight: bold;">⚠ Warning: rigbook has no authentication. Serving on a public network is not recommended.</span>

--- a/frontend/src/Settings.svelte
+++ b/frontend/src/Settings.svelte
@@ -2499,7 +2499,7 @@
 
   <section class="settings-section">
     <h3>Network</h3>
-    <span class="hint">These settings require restarting rigbook.</span>
+    <span class="hint">Changing these settings requires restarting rigbook.</span>
     <div class="setting-row">
       <label for="global_default_host">Default Host</label>
       <input id="global_default_host" type="text" bind:value={global_default_host} on:blur={() => saveGlobalSetting("default_host", global_default_host.trim())} autocomplete="off" style="max-width: 10rem" />

--- a/src/rigbook/db.py
+++ b/src/rigbook/db.py
@@ -45,6 +45,7 @@ GLOBAL_DEFAULTABLE_KEYS = {
 GLOBAL_ONLY_KEYS = {
     "update_check_enabled",
     "default_pick_mode",
+    "default_host",
     "default_port",
     "update_skip_version",
     "shutdown_in_menu",

--- a/src/rigbook/main.py
+++ b/src/rigbook/main.py
@@ -646,7 +646,25 @@ def run() -> None:
     logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("httpx").setLevel(logging.WARNING)
 
-    host = os.environ.get("RIGBOOK_HOST", "127.0.0.1")
+    host = os.environ.get("RIGBOOK_HOST", "")
+    if not host:
+        try:
+            import sqlite3 as _sqlite3
+
+            from rigbook.db import META_DB_PATH
+
+            if META_DB_PATH.exists():
+                _conn = _sqlite3.connect(str(META_DB_PATH))
+                _row = _conn.execute(
+                    "SELECT value FROM settings WHERE key = 'default_host'"
+                ).fetchone()
+                _conn.close()
+                if _row and _row[0]:
+                    host = _row[0]
+        except Exception:
+            pass
+        if not host:
+            host = "127.0.0.1"
     port = args.port or int(os.environ.get("RIGBOOK_PORT", "8073"))
 
     # Check if rigbook is already running on this port (works in all modes including picker)


### PR DESCRIPTION
## Summary
- Add `default_host` as a global setting so the bind address can be configured from the UI (#175)
- Backend reads the setting on startup (env var `RIGBOOK_HOST` still takes precedence)
- Show warning when host is not `127.0.0.1` (no authentication)
- Add inline Reset button to restore default `127.0.0.1`
- Add hint that Network settings require a restart