### PR TITLE
Fix Add QSO button visibility with theme accent color (#183)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2109,7 +2109,7 @@
   .add-btn {
     background: color-mix(in srgb, var(--accent) 15%, var(--bg-card));
     box-shadow: var(--glow-shadow-sm);
-    color: #fff;
+    color: var(--accent);
     border: none;
     font-size: 1.2rem;
     font-weight: bold;
@@ -2122,6 +2122,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+  .add-btn :global(svg path) {
+    fill: currentColor;
   }
 
   .add-btn.dual-btn {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -1529,7 +1529,7 @@
         </button>
         {#if solarEnabled}<button class="add-btn" on:click={() => navigate("conditions")} title="Conditions"><Icon icon={iconSun} width={18} /></button>{/if}
       {/if}
-      <button class="add-btn" on:click={() => { dualShowForm = true; prefill = null; editId = null; if (page === "dual") { /* already on dual */ } else navigate("add"); }} title="Add QSO"><Icon icon={iconPlus} width={18} /></button>
+      <button class="add-btn add-qso-btn" on:click={() => { dualShowForm = true; prefill = null; editId = null; if (page === "dual") { /* already on dual */ } else navigate("add"); }} title="Add QSO"><Icon icon={iconPlus} width={18} /></button>
       <button class="hamburger" on:click={() => menuOpen = !menuOpen} aria-label="Menu">
         <span class="bar"></span>
         <span class="bar"></span>
@@ -2109,7 +2109,7 @@
   .add-btn {
     background: color-mix(in srgb, var(--accent) 15%, var(--bg-card));
     box-shadow: var(--glow-shadow-sm);
-    color: var(--accent);
+    color: #fff;
     border: none;
     font-size: 1.2rem;
     font-weight: bold;
@@ -2123,9 +2123,6 @@
     align-items: center;
     justify-content: center;
   }
-  .add-btn :global(svg path) {
-    fill: currentColor;
-  }
 
   .add-btn.dual-btn {
     width: auto;
@@ -2138,6 +2135,10 @@
 
   .add-btn:hover {
     background: color-mix(in srgb, var(--accent) 30%, var(--bg-card));
+  }
+
+  .add-qso-btn :global(svg path) {
+    fill: var(--accent);
   }
 
   .notification-btn {


### PR DESCRIPTION
## Summary
- Make the Add QSO (+) button icon use the theme's accent color instead of a hardcoded dark fill that's invisible on dark themes
- Scoped to the Add QSO button only — other nav icons unchanged

Fixes #183