### PR TITLE
Use platform-specific data directories (#187)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,11 @@ rigbook/
 
 ## Data Storage
 
-Database and config stored in `~/.local/rigbook/rigbook.db` (XDG-compatible). Created automatically on first run.
+Database and config stored in a platform-specific data directory. Created automatically on first run.
+
+- **Linux**: `~/.local/share/rigbook/` (XDG-compatible)
+- **macOS**: `~/Library/Application Support/rigbook/`
+- **Windows**: `%APPDATA%\rigbook\`
 
 ## Key Commands
 

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ See [TERMUX.md](TERMUX.md) for instructions on running Rigbook on Android via Te
 ### Container
 
 ```bash
-mkdir -p ${HOME}/.local/rigbook && \
+mkdir -p ${HOME}/.local/share/rigbook && \
 podman run --rm -it --name rigbook \
   --network=host \
-  -v ${HOME}/.local/rigbook:/root/.local/rigbook:Z \
+  -v ${HOME}/.local/share/rigbook:/root/.local/share/rigbook:Z \
   ghcr.io/enigmacurry/rigbook:latest
 ```
 
@@ -133,7 +133,7 @@ instead.
 
 | Variable | Description |
 |---|---|
-| `RIGBOOK_DB` | Logbook name (e.g. `field-day` opens `~/.local/rigbook/field-day.db`) |
+| `RIGBOOK_DB` | Logbook name (e.g. `field-day` opens `field-day.db` in the data directory) |
 | `RIGBOOK_PICKER` | `true` to start in logbook picker mode |
 | `RIGBOOK_NO_BROWSER` | `true` to skip opening the browser |
 | `RIGBOOK_NO_SHUTDOWN` | `true` to disable the shutdown endpoint and auto-shutdown |
@@ -161,8 +161,13 @@ just check         # Lint and format check
 just fix           # Auto-fix lint and formatting
 ```
 
-Data is stored in `~/.local/rigbook/` (SQLite). Automatic backups are
-configurable in Settings.
+Data is stored in a platform-specific directory (SQLite):
+
+- **Linux**: `~/.local/share/rigbook/`
+- **macOS**: `~/Library/Application Support/rigbook/`
+- **Windows**: `%APPDATA%\rigbook\`
+
+Automatic backups are configurable in Settings.
 
 ## License
 

--- a/src/rigbook/db.py
+++ b/src/rigbook/db.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import shutil
 import sys
 import time
 import uuid as _uuid
@@ -15,9 +16,58 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 logger = logging.getLogger("rigbook")
 
-DB_DIR = Path.home() / ".local" / "rigbook"
+LEGACY_DB_DIR = Path.home() / ".local" / "rigbook"
+
+
+def _get_data_dir() -> Path:
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "rigbook"
+    elif sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / "rigbook"
+        return Path.home() / "AppData" / "Roaming" / "rigbook"
+    else:
+        xdg = os.environ.get("XDG_DATA_HOME")
+        if xdg:
+            return Path(xdg) / "rigbook"
+        return Path.home() / ".local" / "share" / "rigbook"
+
+
+DB_DIR = _get_data_dir()
 META_DB_PATH = DB_DIR / "__global.db"
 _LAST_OPENED_FILE = DB_DIR / "last_opened.json"
+
+
+def migrate_legacy_data_dir() -> None:
+    """Migrate data from the legacy ~/.local/rigbook to the new platform dir."""
+    if LEGACY_DB_DIR == DB_DIR:
+        return
+    if not LEGACY_DB_DIR.is_dir():
+        return
+    # Only migrate if the new dir doesn't exist or is empty
+    if DB_DIR.is_dir() and any(DB_DIR.iterdir()):
+        return
+    DB_DIR.mkdir(parents=True, exist_ok=True)
+    migrated = []
+    for item in LEGACY_DB_DIR.iterdir():
+        if item.name == "MOVED.txt":
+            continue
+        dest = DB_DIR / item.name
+        shutil.move(str(item), str(dest))
+        migrated.append(item.name)
+    if migrated:
+        logger.info(
+            "Migrated %d items from %s to %s: %s",
+            len(migrated),
+            LEGACY_DB_DIR,
+            DB_DIR,
+            ", ".join(sorted(migrated)),
+        )
+        breadcrumb = LEGACY_DB_DIR / "MOVED.txt"
+        breadcrumb.write_text(
+            f"Rigbook data has been moved to:\n{DB_DIR}\n"
+        )
 
 # Settings that can be set globally in __global.db and overridden per-logbook
 GLOBAL_DEFAULTABLE_KEYS = {
@@ -726,6 +776,7 @@ def cleanup_stale_locks() -> None:
 
 
 async def init_db() -> None:
+    migrate_legacy_data_dir()
     DB_DIR.mkdir(parents=True, exist_ok=True)
     cleanup_stale_locks()
     await db_manager.open_global()

--- a/src/rigbook/main.py
+++ b/src/rigbook/main.py
@@ -623,8 +623,9 @@ def run() -> None:
         or (sys.platform == "darwin" and not sys.stderr.isatty())
     )
     if _log_to_file:
-        from rigbook.db import DB_DIR
+        from rigbook.db import DB_DIR, migrate_legacy_data_dir
 
+        migrate_legacy_data_dir()
         DB_DIR.mkdir(parents=True, exist_ok=True)
         handler = logging.FileHandler(DB_DIR / "rigbook.log", encoding="utf-8")
         handler.setFormatter(


### PR DESCRIPTION
## Summary
- Use OS-native data directories instead of hardcoded `~/.local/rigbook/`:
  - Linux: `~/.local/share/rigbook/` (proper XDG)
  - macOS: `~/Library/Application Support/rigbook/`
  - Windows: `%APPDATA%\rigbook\`
- Auto-migrate data from legacy directory on first run
- Updated README and CLAUDE.md with new paths

Closes #187