### PR TITLE
Add cw_key_type field for CW key reporting

### DIFF
--- a/frontend/src/Logbook.svelte
+++ b/frontend/src/Logbook.svelte
@@ -1191,6 +1191,17 @@
       <label>Mode *</label>
       <Autocomplete bind:value={mode} items={availableModes} />
     </div>
+    {#if mode.toUpperCase() === "CW"}
+    <div class="field" class:changed={orig && cw_key_type !== orig.cw_key_type}>
+      <label for="cw_key_type">CW Key{#if cw_key_type === "SK"} — Straight{:else if cw_key_type === "BUG"} — Bug{:else if cw_key_type === "SS"} — Sideswiper{/if}</label>
+      <select id="cw_key_type" bind:value={cw_key_type}>
+        <option value="">—</option>
+        <option value="SK">SK</option>
+        <option value="BUG">BUG</option>
+        <option value="SS">SS</option>
+      </select>
+    </div>
+    {/if}
     <div class="field" class:changed={orig && rst_sent !== orig.rst_sent}>
       <label for="rst_sent">RST Sent</label>
       <input id="rst_sent" type="text" bind:value={rst_sent} />
@@ -1269,15 +1280,6 @@
         <input id="skcc" type="text" bind:value={skcc} on:input={stripSkcc} style="text-transform: uppercase" readonly={skcc_exch} />
         <button type="button" class="skcc-exch-btn" class:active={skcc_exch} disabled={!skccValid} on:click={() => skcc_exch = !skcc_exch} title="Valid SKCC exchange (RST, QTH, Name, SKCC#)"><Icon icon={iconCheck} width={16} inline={true} /></button>
       </div>
-    </div>
-    <div class="field" class:changed={orig && cw_key_type !== orig.cw_key_type}>
-      <label for="cw_key_type">CW Key{#if cw_key_type === "SK"} — Straight{:else if cw_key_type === "BUG"} — Bug{:else if cw_key_type === "SS"} — Sideswiper{/if}</label>
-      <select id="cw_key_type" bind:value={cw_key_type}>
-        <option value="">—</option>
-        <option value="SK">SK</option>
-        <option value="BUG">BUG</option>
-        <option value="SS">SS</option>
-      </select>
     </div>
     {/if}
     <div class="field wide" class:changed={orig && comments !== orig.comments}>

--- a/frontend/src/Logbook.svelte
+++ b/frontend/src/Logbook.svelte
@@ -1270,7 +1270,7 @@
         <button type="button" class="skcc-exch-btn" class:active={skcc_exch} disabled={!skccValid} on:click={() => skcc_exch = !skcc_exch} title="Valid SKCC exchange (RST, QTH, Name, SKCC#)"><Icon icon={iconCheck} width={16} inline={true} /></button>
       </div>
     </div>
-    <div class="field field-cw-key" class:changed={orig && cw_key_type !== orig.cw_key_type}>
+    <div class="field" class:changed={orig && cw_key_type !== orig.cw_key_type}>
       <label for="cw_key_type">CW Key{#if cw_key_type === "SK"} — Straight{:else if cw_key_type === "BUG"} — Bug{:else if cw_key_type === "SS"} — Sideswiper{/if}</label>
       <select id="cw_key_type" bind:value={cw_key_type}>
         <option value="">—</option>
@@ -1502,10 +1502,7 @@
     min-width: 240px;
   }
 
-  .field-cw-key {
-    flex: 0 0 auto;
-    min-width: 0;
-  }
+
 
   .time-btn-group {
     display: flex;

--- a/frontend/src/Logbook.svelte
+++ b/frontend/src/Logbook.svelte
@@ -40,6 +40,7 @@
   let grid = "";
   let skcc = "";
   let skcc_exch = false;
+  let cw_key_type = localStorage.getItem("rigbook_cw_key_type") || "";
   let tableWrapEl;
   function utcNowDate() { return new Date().toISOString().slice(0, 10); }
   function utcNowTime() { return new Date().toISOString().slice(11, 19); }
@@ -210,7 +211,7 @@
   export let activePark = "";
 
   function formSnapshot() {
-    return { call, freq, mode, rst_sent, rst_recv, pota_park, name, qth, state, country, grid, skcc, skcc_exch, comments, notes, datePart, timePart, datePartOff, timePartOff };
+    return { call, freq, mode, rst_sent, rst_recv, pota_park, name, qth, state, country, grid, skcc, skcc_exch, cw_key_type, comments, notes, datePart, timePart, datePartOff, timePartOff };
   }
 
   $: editHasChanges = !editingId || !editOriginal || (
@@ -227,6 +228,7 @@
     grid !== editOriginal.grid ||
     skcc !== editOriginal.skcc ||
     skcc_exch !== editOriginal.skcc_exch ||
+    cw_key_type !== editOriginal.cw_key_type ||
     comments !== editOriginal.comments ||
     notes !== editOriginal.notes ||
     datePart !== editOriginal.datePart ||
@@ -254,6 +256,7 @@
     grid !== addOriginal.grid ||
     skcc !== addOriginal.skcc ||
     skcc_exch !== addOriginal.skcc_exch ||
+    cw_key_type !== addOriginal.cw_key_type ||
     comments !== addOriginal.comments ||
     notes !== addOriginal.notes ||
     (clockState === "STATIC" && datePart !== addOriginal.datePart) ||
@@ -283,6 +286,7 @@
     rst_recv: { key: "rst_recv", label: "RST R" },
     comments: { key: "comments", label: "Comments" },
     updated_at: { key: "updated_at", label: "Edited" },
+    cw_key_type: { key: "cw_key_type", label: "CW Key" },
   };
 
   function loadColumnOrder() {
@@ -546,6 +550,7 @@
     grid = "";
     skcc = "";
     skcc_exch = false;
+    cw_key_type = localStorage.getItem("rigbook_cw_key_type") || "";
     comments = "";
     notes = "";
     datePart = "";
@@ -644,7 +649,7 @@
       }
       // Update addOriginal so auto-filled fields don't make form dirty
       if (!editingId && addOriginal) {
-        addOriginal = { ...addOriginal, name, qth, state, country, grid, skcc, skcc_exch };
+        addOriginal = { ...addOriginal, name, qth, state, country, grid, skcc, skcc_exch, cw_key_type };
       }
     } catch {}
   }
@@ -692,6 +697,7 @@
   function isValidSkccNumber(val) { return SKCC_NUMBER_RE.test(val.trim().toUpperCase()); }
   $: skccValid = isValidSkccNumber(skcc);
   $: stripSkcc = () => { skcc = skcc.replace(/[^A-Za-z0-9]/g, ""); if (!isValidSkccNumber(skcc)) skcc_exch = false; };
+  $: if (cw_key_type) localStorage.setItem("rigbook_cw_key_type", cw_key_type); else localStorage.removeItem("rigbook_cw_key_type");
 
   // POTA park autocomplete
   let potaResults = [];
@@ -834,6 +840,7 @@
     grid = c.grid || "";
     skcc = c.skcc || "";
     skcc_exch = !!c.skcc_exch;
+    cw_key_type = c.cw_key_type || "";
     comments = c.comments || "";
     notes = c.notes || "";
     if (c.timestamp) {
@@ -857,7 +864,7 @@
     errorMsg = "";
     editOriginal = {
       call, freq, mode, rst_sent, rst_recv, pota_park, name, qth,
-      state, country, grid, skcc, skcc_exch, comments, notes, datePart, timePart,
+      state, country, grid, skcc, skcc_exch, cw_key_type, comments, notes, datePart, timePart,
       datePartOff, timePartOff,
     };
     const match = countries.find(co => co.name === country);
@@ -913,6 +920,7 @@
         grid: grid.trim().toUpperCase() || null,
         skcc: skcc.trim().toUpperCase() || null,
         skcc_exch: skcc_exch,
+        cw_key_type: cw_key_type || null,
         comments: comments || null,
         notes: notes || null,
         timestamp: `${datePart}T${timePart || "00:00:00"}Z`,
@@ -962,6 +970,7 @@
     grid = "";
     skcc = "";
     skcc_exch = false;
+    cw_key_type = localStorage.getItem("rigbook_cw_key_type") || "";
     comments = "";
     notes = "";
     datePart = "";
@@ -1003,6 +1012,7 @@
         grid: grid.trim().toUpperCase() || null,
         skcc: skcc.trim().toUpperCase() || null,
         skcc_exch: skcc_exch,
+        cw_key_type: cw_key_type || null,
         comments: comments || null,
         notes: notes || null,
         timestamp: `${datePart}T${timePart || "00:00:00"}Z`,
@@ -1252,6 +1262,7 @@
         {/if}
       </div>
     </div>
+    {#if mode.toUpperCase() === "CW"}
     <div class="field" class:changed={orig && (skcc !== orig.skcc || skcc_exch !== orig.skcc_exch)}>
       <label for="skcc">SKCC # / {skcc_exch ? "Validated!" : "Validated?"}</label>
       <div class="skcc-input-row">
@@ -1259,6 +1270,16 @@
         <button type="button" class="skcc-exch-btn" class:active={skcc_exch} disabled={!skccValid} on:click={() => skcc_exch = !skcc_exch} title="Valid SKCC exchange (RST, QTH, Name, SKCC#)"><Icon icon={iconCheck} width={16} inline={true} /></button>
       </div>
     </div>
+    <div class="field" class:changed={orig && cw_key_type !== orig.cw_key_type}>
+      <label for="cw_key_type">CW Key</label>
+      <select id="cw_key_type" bind:value={cw_key_type}>
+        <option value="">—</option>
+        <option value="SK">Straight Key</option>
+        <option value="BUG">Bug</option>
+        <option value="SS">Sideswiper</option>
+      </select>
+    </div>
+    {/if}
     <div class="field wide" class:changed={orig && comments !== orig.comments}>
       <label for="comments">Comments (public)</label>
       <input id="comments" type="text" bind:value={comments} />
@@ -1374,6 +1395,7 @@
                 {:else if col.key === "rst_recv"}<td>{c.rst_recv || ""}</td>
                 {:else if col.key === "comments"}<td class="truncate">{c.comments || ""}</td>
                 {:else if col.key === "updated_at"}<td>{c.updated_at ? formatTimestamp(c.updated_at) : ""}</td>
+                {:else if col.key === "cw_key_type"}<td>{c.cw_key_type || ""}</td>
                 {/if}
               {/each}
             </tr>
@@ -1585,7 +1607,8 @@
   }
 
   input,
-  textarea {
+  textarea,
+  select {
     background: var(--bg-input);
     border: 1px solid var(--border-input);
     color: var(--text);
@@ -1596,7 +1619,8 @@
   }
 
   input:focus,
-  textarea:focus {
+  textarea:focus,
+  select:focus {
     outline: none;
     border-color: var(--accent);
   }

--- a/frontend/src/Logbook.svelte
+++ b/frontend/src/Logbook.svelte
@@ -1272,11 +1272,11 @@
     </div>
     <div class="field field-cw-key" class:changed={orig && cw_key_type !== orig.cw_key_type}>
       <label for="cw_key_type">CW Key</label>
-      <select id="cw_key_type" bind:value={cw_key_type}>
+      <select id="cw_key_type" bind:value={cw_key_type} title={cw_key_type === "SK" ? "Straight Key" : cw_key_type === "BUG" ? "Bug" : cw_key_type === "SS" ? "Sideswiper" : "CW Key Type"}>
         <option value="">—</option>
-        <option value="SK">SK</option>
-        <option value="BUG">BUG</option>
-        <option value="SS">SS</option>
+        <option value="SK" title="Straight Key">SK</option>
+        <option value="BUG" title="Bug">BUG</option>
+        <option value="SS" title="Sideswiper">SS</option>
       </select>
     </div>
     {/if}

--- a/frontend/src/Logbook.svelte
+++ b/frontend/src/Logbook.svelte
@@ -1274,9 +1274,9 @@
       <label for="cw_key_type">CW Key</label>
       <select id="cw_key_type" bind:value={cw_key_type}>
         <option value="">—</option>
-        <option value="SK">Straight Key</option>
-        <option value="BUG">Bug</option>
-        <option value="SS">Sideswiper</option>
+        <option value="SK">SK</option>
+        <option value="BUG">BUG</option>
+        <option value="SS">SS</option>
       </select>
     </div>
     {/if}
@@ -1505,7 +1505,7 @@
   .field-cw-key {
     flex: 0 0 auto;
     min-width: 0;
-    max-width: 120px;
+    max-width: 80px;
   }
 
   .time-btn-group {

--- a/frontend/src/Logbook.svelte
+++ b/frontend/src/Logbook.svelte
@@ -1270,7 +1270,7 @@
         <button type="button" class="skcc-exch-btn" class:active={skcc_exch} disabled={!skccValid} on:click={() => skcc_exch = !skcc_exch} title="Valid SKCC exchange (RST, QTH, Name, SKCC#)"><Icon icon={iconCheck} width={16} inline={true} /></button>
       </div>
     </div>
-    <div class="field" class:changed={orig && cw_key_type !== orig.cw_key_type}>
+    <div class="field field-cw-key" class:changed={orig && cw_key_type !== orig.cw_key_type}>
       <label for="cw_key_type">CW Key</label>
       <select id="cw_key_type" bind:value={cw_key_type}>
         <option value="">—</option>
@@ -1500,6 +1500,12 @@
   .field.wide {
     flex: 2;
     min-width: 240px;
+  }
+
+  .field-cw-key {
+    flex: 0 0 auto;
+    min-width: 0;
+    max-width: 120px;
   }
 
   .time-btn-group {

--- a/frontend/src/Logbook.svelte
+++ b/frontend/src/Logbook.svelte
@@ -1271,12 +1271,12 @@
       </div>
     </div>
     <div class="field field-cw-key" class:changed={orig && cw_key_type !== orig.cw_key_type}>
-      <label for="cw_key_type">CW Key</label>
-      <select id="cw_key_type" bind:value={cw_key_type} title={cw_key_type === "SK" ? "Straight Key" : cw_key_type === "BUG" ? "Bug" : cw_key_type === "SS" ? "Sideswiper" : "CW Key Type"}>
+      <label for="cw_key_type">CW Key{#if cw_key_type === "SK"} — Straight{:else if cw_key_type === "BUG"} — Bug{:else if cw_key_type === "SS"} — Sideswiper{/if}</label>
+      <select id="cw_key_type" bind:value={cw_key_type}>
         <option value="">—</option>
-        <option value="SK" title="Straight Key">SK</option>
-        <option value="BUG" title="Bug">BUG</option>
-        <option value="SS" title="Sideswiper">SS</option>
+        <option value="SK">SK</option>
+        <option value="BUG">BUG</option>
+        <option value="SS">SS</option>
       </select>
     </div>
     {/if}
@@ -1505,7 +1505,6 @@
   .field-cw-key {
     flex: 0 0 auto;
     min-width: 0;
-    max-width: 80px;
   }
 
   .time-btn-group {

--- a/src/rigbook/db.py
+++ b/src/rigbook/db.py
@@ -65,9 +65,8 @@ def migrate_legacy_data_dir() -> None:
             ", ".join(sorted(migrated)),
         )
         breadcrumb = LEGACY_DB_DIR / "MOVED.txt"
-        breadcrumb.write_text(
-            f"Rigbook data has been moved to:\n{DB_DIR}\n"
-        )
+        breadcrumb.write_text(f"Rigbook data has been moved to:\n{DB_DIR}\n")
+
 
 # Settings that can be set globally in __global.db and overridden per-logbook
 GLOBAL_DEFAULTABLE_KEYS = {
@@ -176,6 +175,7 @@ class Contact(Base):
     grid: Mapped[str | None] = mapped_column(String, nullable=True)
     skcc: Mapped[str | None] = mapped_column(String, nullable=True)
     skcc_exch: Mapped[int | None] = mapped_column(Integer, nullable=True, default=0)
+    cw_key_type: Mapped[str | None] = mapped_column(String, nullable=True)
     comments: Mapped[str | None] = mapped_column(String, nullable=True)
     notes: Mapped[str | None] = mapped_column(String, nullable=True)
     timestamp: Mapped[datetime] = mapped_column(
@@ -388,9 +388,7 @@ def _run_migrations(conn, migrations, table="settings") -> bool:
             migrate_fn(conn)
         _set_schema_version(conn, table, expected)
         _set_last_migrated_by(conn, table)
-        logger.info(
-            "Migrated %s schema: v%d → v%d", table, current, expected
-        )
+        logger.info("Migrated %s schema: v%d → v%d", table, current, expected)
         return True
     return False
 
@@ -585,9 +583,7 @@ class DatabaseManager:
                 current_v = 0
             _conn.close()
             if current_v < len(LOGBOOK_MIGRATIONS):
-                _backup_before_migration(
-                    db_path, current_v, len(LOGBOOK_MIGRATIONS)
-                )
+                _backup_before_migration(db_path, current_v, len(LOGBOOK_MIGRATIONS))
         self.engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
         self._session_factory = async_sessionmaker(self.engine, expire_on_commit=False)
         migrated = [False]
@@ -614,9 +610,7 @@ class DatabaseManager:
                 await conn.execute(text("VACUUM"))
                 logger.info("Vacuumed logbook database after migration")
         async with self.engine.connect() as conn:
-            sv = await conn.run_sync(
-                lambda c: _get_schema_version(c, "settings")
-            )
+            sv = await conn.run_sync(lambda c: _get_schema_version(c, "settings"))
         await self.record_last_opened(db_path.stem)
         logger.info("Opened logbook: %s (schema v%d)", db_path, sv)
 
@@ -665,9 +659,7 @@ class DatabaseManager:
         # Migrate last_opened.json if it exists
         await self._migrate_last_opened()
         async with self.global_engine.connect() as conn:
-            gsv = await conn.run_sync(
-                lambda c: _get_schema_version(c, "settings")
-            )
+            gsv = await conn.run_sync(lambda c: _get_schema_version(c, "settings"))
         logger.info("Opened global database: %s (schema v%d)", META_DB_PATH, gsv)
 
     async def close_global(self) -> None:
@@ -741,9 +733,7 @@ def global_async_session():
     return db_manager._global_session_factory()
 
 
-async def resolve_setting(
-    key: str, session: AsyncSession, default: str = ""
-) -> str:
+async def resolve_setting(key: str, session: AsyncSession, default: str = "") -> str:
     """Read a setting from the logbook DB, falling back to global DB if blank/missing."""
     result = await session.execute(select(Setting).where(Setting.key == key))
     row = result.scalar_one_or_none()

--- a/src/rigbook/routes/adif.py
+++ b/src/rigbook/routes/adif.py
@@ -144,6 +144,7 @@ def render_comment_with_template(
         "pota_park": c.pota_park,
         "skcc": c.skcc,
         "skcc_exch": "Y" if c.skcc_exch else "",
+        "cw_key_type": c.cw_key_type or "",
         "dxcc": str(c.dxcc) if c.dxcc is not None else "",
     }
     parts = []
@@ -196,6 +197,8 @@ def contact_to_adif_record(
         record["SKCC"] = str(c.skcc)
     if c.skcc_exch:
         record["APP_RIGBOOK_SKCC_EXCH"] = "Y"
+    if c.cw_key_type:
+        record["APP_RIGBOOK_CW_KEY_TYPE"] = c.cw_key_type
     if comment_template:
         comment = render_comment_with_template(comment_template, c, comment_separator)
         if comment:
@@ -382,6 +385,11 @@ def adif_record_to_contact_dict(record: dict) -> dict:
         data["skcc"] = skcc
     if record.get("APP_RIGBOOK_SKCC_EXCH", "").upper() == "Y":
         data["skcc_exch"] = 1
+    cw_key_type = record.get("APP_RIGBOOK_CW_KEY_TYPE") or record.get(
+        "APP_SKCCLOGGER_KEYTYPE"
+    )
+    if cw_key_type:
+        data["cw_key_type"] = cw_key_type
     data["comments"] = record.get("COMMENT")
     data["notes"] = record.get("NOTES")
     app_uuid = record.get("APP_RIGBOOK_UUID")
@@ -754,6 +762,7 @@ MERGE_FIELDS = [
     ("pota_park", "POTA"),
     ("skcc", "SKCC"),
     ("skcc_exch", "SKCC Exch"),
+    ("cw_key_type", "CW Key"),
     ("comments", "Comments"),
     ("notes", "Notes"),
 ]
@@ -946,6 +955,8 @@ ADIF_FIELD_MAP = {
     "POTA_REF": "pota_park",
     "SKCC": "skcc",
     "DXCC": "dxcc",
+    "APP_RIGBOOK_CW_KEY_TYPE": "cw_key_type",
+    "APP_SKCCLOGGER_KEYTYPE": "cw_key_type",
 }
 
 DEFAULT_LABELS = {
@@ -962,6 +973,7 @@ DEFAULT_LABELS = {
     "pota_park": "POTA",
     "skcc": "SKCC",
     "skcc_exch": "SKCC Exch",
+    "cw_key_type": "CW Key",
     "dxcc": "DXCC",
 }
 
@@ -1034,7 +1046,7 @@ def _suggest_comment_template(records: list[dict]) -> dict:
             ]
 
     # Only suggest fields that belong to our curated template set
-    allowed = {"skcc", "skcc_exch", "pota_park", "dxcc"}
+    allowed = {"skcc", "skcc_exch", "cw_key_type", "pota_park", "dxcc"}
     best_fields = [f for f in best_fields if f["field"] in allowed]
     return {"separator": best_sep, "fields": best_fields}
 
@@ -1088,6 +1100,7 @@ async def preview_import_adif(
             "grid": data.get("grid"),
             "skcc": data.get("skcc"),
             "skcc_exch": bool(data.get("skcc_exch")),
+            "cw_key_type": data.get("cw_key_type"),
             "comments": data.get("comments"),
             "original_comment": data.get("_original_comment"),
             "notes": data.get("notes"),
@@ -1173,6 +1186,7 @@ IMPORT_FIELDS = {
     "pota_park",
     "skcc",
     "skcc_exch",
+    "cw_key_type",
     "comments",
     "notes",
     "timestamp_off",

--- a/src/rigbook/routes/contacts.py
+++ b/src/rigbook/routes/contacts.py
@@ -30,6 +30,7 @@ class ContactCreate(BaseModel):
     grid: str | None = None
     skcc: str | None = None
     skcc_exch: bool = False
+    cw_key_type: str | None = None
     comments: str | None = None
     notes: str | None = None
     timestamp: datetime | None = None
@@ -98,6 +99,7 @@ class ContactUpdate(BaseModel):
     grid: str | None = None
     skcc: str | None = None
     skcc_exch: bool | None = None
+    cw_key_type: str | None = None
     comments: str | None = None
     notes: str | None = None
     timestamp: datetime | None = None
@@ -142,6 +144,7 @@ class ContactResponse(BaseModel):
     grid: str | None
     skcc: str | None
     skcc_exch: bool = False
+    cw_key_type: str | None = None
     comments: str | None
     notes: str | None
     timestamp: datetime


### PR DESCRIPTION
Closes #192 (sub-issue of #191, part 1)

## Summary

- Adds `cw_key_type` field to QSO contacts (values: SK, BUG, SS, or empty)
- Form shows CW Key dropdown and SKCC fields only when mode is CW
- CW Key selection is sticky via localStorage across QSOs and page reloads
- ADIF export writes `APP_RIGBOOK_CW_KEY_TYPE`; import reads both `APP_RIGBOOK_CW_KEY_TYPE` and `APP_SKCCLOGGER_KEYTYPE` for SKCCLogger compatibility
- Column available in log table via column picker (not shown by default)

## Files changed

- `src/rigbook/db.py` — new `cw_key_type` column on Contact model
- `src/rigbook/routes/contacts.py` — added to Pydantic models
- `src/rigbook/routes/adif.py` — export/import mapping, field maps, merge fields
- `frontend/src/Logbook.svelte` — form UI, conditional visibility, localStorage persistence, table column