### PR TITLE
Add tx_pwr field with flrig integration

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -214,6 +214,7 @@
   let appFrozen = true;
   let vfoFreq = "";
   let vfoMode = "";
+  let vfoPower = "";
   let vfoConnected = false;
   let vfoEditing = false;
   let vfoFreqInput;
@@ -731,11 +732,13 @@
         const data = await res.json();
         vfoFreq = data.freq || "";
         vfoMode = data.mode || "";
+        vfoPower = data.power || "";
         vfoConnected = data.connected;
       }
     } catch {
       vfoFreq = "";
       vfoMode = "";
+      vfoPower = "";
       vfoConnected = false;
     }
   }
@@ -1500,6 +1503,9 @@
           <!-- svelte-ignore a11y-no-static-element-interactions -->
           <span class="vfo-mode" on:click={cycleMode} title="Click or press M to cycle mode">{vfoMode}</span>
         {/if}
+        {#if vfoPower}
+          <span class="vfo-power" title="TX Power">{vfoPower}W</span>
+        {/if}
       {:else if flrigEnabled}
         <span class="vfo disconnected" title="Radio not connected"><Icon icon={iconCross} width={14} /> No Radio</span>
       {/if}
@@ -1571,7 +1577,7 @@
   {#if page === "dual"}
     <div class="dual-layout" class:dual-narrow={!wide} class:dragging={draggingSplit} class:dual-reversed={logbookRight}>
       <div class="dual-pane" style="flex: 0 0 {dualSplit}%">
-        <Logbook {wide} {logbookRight} showForm={dualShowForm || !!prefill || !!editId} {prefill} {editId} {vfoFreq} {vfoMode} bind:formDirty bind:activePark on:addqso={() => { dualShowForm = true; prefill = null; editId = null; }} on:editchange={e => { editId = e.detail; dualShowForm = !!e.detail; }} on:navigate={e => { if (e.detail === "hunting" || e.detail === "log" || e.detail === "back") { prefill = null; editId = null; dualShowForm = false; dualHunting?.refreshAwards(); if (!wide) navigate(dualRightPage); } else navigate(e.detail); }} on:prefillconsumed={() => prefill = null} on:parkschanged={() => dualParks?.refreshParks()} />
+        <Logbook {wide} {logbookRight} showForm={dualShowForm || !!prefill || !!editId} {prefill} {editId} {vfoFreq} {vfoMode} {vfoPower} bind:formDirty bind:activePark on:addqso={() => { dualShowForm = true; prefill = null; editId = null; }} on:editchange={e => { editId = e.detail; dualShowForm = !!e.detail; }} on:navigate={e => { if (e.detail === "hunting" || e.detail === "log" || e.detail === "back") { prefill = null; editId = null; dualShowForm = false; dualHunting?.refreshAwards(); if (!wide) navigate(dualRightPage); } else navigate(e.detail); }} on:prefillconsumed={() => prefill = null} on:parkschanged={() => dualParks?.refreshParks()} />
       </div>
       <!-- svelte-ignore a11y-no-static-element-interactions -->
       <div class="dual-divider" on:mousedown={onDividerDown} on:touchstart={onDividerDown}></div>
@@ -1598,9 +1604,9 @@
   {:else}
     <div class="page-content">
     {#if page === "log"}
-      <Logbook showForm={false} {vfoFreq} {vfoMode} on:editchange={e => { editId = e.detail; navigate("add"); window.location.hash = `/log/${e.detail}`; }} on:navigate={e => navigate(e.detail)} />
+      <Logbook showForm={false} {vfoFreq} {vfoMode} {vfoPower} on:editchange={e => { editId = e.detail; navigate("add"); window.location.hash = `/log/${e.detail}`; }} on:navigate={e => navigate(e.detail)} />
     {:else if page === "add"}
-      <Logbook showForm={true} {editId} {prefill} {vfoFreq} {vfoMode} bind:formDirty bind:activePark on:editchange={e => { editId = e.detail; window.location.hash = e.detail ? `/log/${e.detail}` : "/add"; }} on:navigate={e => navigate(e.detail)} on:prefillconsumed={() => prefill = null} on:parkschanged={() => dualParks?.refreshParks()} />
+      <Logbook showForm={true} {editId} {prefill} {vfoFreq} {vfoMode} {vfoPower} bind:formDirty bind:activePark on:editchange={e => { editId = e.detail; window.location.hash = e.detail ? `/log/${e.detail}` : "/add"; }} on:navigate={e => navigate(e.detail)} on:prefillconsumed={() => prefill = null} on:parkschanged={() => dualParks?.refreshParks()} />
     {:else if page === "hunting"}
       <Hunting {potaEnabled} {spotsEnabled} on:tune={e => tuneOnly(e.detail)} on:addqso={e => tuneAndPrefill(e.detail)} />
     {:else if page === "search"}
@@ -1614,7 +1620,7 @@
     {:else if page === "notifications"}
       <Notifications refreshTrigger={notifRefreshTrigger} on:countchange={() => fetchUnreadCount()} on:tune={e => tuneOnly(e.detail)} on:addqso={e => tuneAndPrefill(e.detail)} />
     {:else if page === "settings"}
-      <Settings logbookName={currentLogbook} pickerMode={pickerMode} {needsSetup} initialTab={settingsTab} bind:highlightSection={settingsHighlight} {clientCount} on:disconnect-others={async () => { const nonce = Math.random().toString(36).slice(2); disconnectNonce = nonce; try { await fetch("/api/events/disconnect-others", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ nonce }) }); } catch {} }} on:deleted={e => { if (e.detail.shutdown) { setShutdownState(); } else { stopAppServices(); logbookOpen = false; currentLogbook = ""; page = "picker"; applySystemTheme(); } }} on:setupcomplete={async () => { needsSetup = false; fetchCallsign(); await fetchLogbookRight(); await fetchSolarEnabled(); await fetchSpotsEnabled(); await fetchPotaEnabled(); await fetchSqlQueryEnabled(); await fetchFlrigEnabled(); if (flrigEnabled && !flrigInterval) { fetchRadioModes(); pollFlrig(); flrigInterval = setInterval(pollFlrig, 2000); } navigate(isWide() ? "dual" : "log"); }} on:saved={async () => { fetchCallsign(); fetchCustomHeader(); fetchDefaultPage(); applyTheme(); fetchPopupNotifEnabled(); await fetchLogbookRight(); await fetchSolarEnabled(); await fetchSpotsEnabled(); await fetchPotaEnabled(); await fetchSqlQueryEnabled(); await fetchFlrigEnabled(); fetchShutdownMenuEnabled(); fetchUpdateCheck(); if (flrigEnabled && !flrigInterval) { fetchRadioModes(); pollFlrig(); flrigInterval = setInterval(pollFlrig, 2000); } else if (!flrigEnabled && flrigInterval) { clearInterval(flrigInterval); flrigInterval = null; vfoFreq = ""; vfoMode = ""; vfoConnected = false; } }} on:shutdown-pending={() => { shutdownPendingSince = Date.now(); }} on:shutdown={() => { setShutdownState(); }} />
+      <Settings logbookName={currentLogbook} pickerMode={pickerMode} {needsSetup} initialTab={settingsTab} bind:highlightSection={settingsHighlight} {clientCount} on:disconnect-others={async () => { const nonce = Math.random().toString(36).slice(2); disconnectNonce = nonce; try { await fetch("/api/events/disconnect-others", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ nonce }) }); } catch {} }} on:deleted={e => { if (e.detail.shutdown) { setShutdownState(); } else { stopAppServices(); logbookOpen = false; currentLogbook = ""; page = "picker"; applySystemTheme(); } }} on:setupcomplete={async () => { needsSetup = false; fetchCallsign(); await fetchLogbookRight(); await fetchSolarEnabled(); await fetchSpotsEnabled(); await fetchPotaEnabled(); await fetchSqlQueryEnabled(); await fetchFlrigEnabled(); if (flrigEnabled && !flrigInterval) { fetchRadioModes(); pollFlrig(); flrigInterval = setInterval(pollFlrig, 2000); } navigate(isWide() ? "dual" : "log"); }} on:saved={async () => { fetchCallsign(); fetchCustomHeader(); fetchDefaultPage(); applyTheme(); fetchPopupNotifEnabled(); await fetchLogbookRight(); await fetchSolarEnabled(); await fetchSpotsEnabled(); await fetchPotaEnabled(); await fetchSqlQueryEnabled(); await fetchFlrigEnabled(); fetchShutdownMenuEnabled(); fetchUpdateCheck(); if (flrigEnabled && !flrigInterval) { fetchRadioModes(); pollFlrig(); flrigInterval = setInterval(pollFlrig, 2000); } else if (!flrigEnabled && flrigInterval) { clearInterval(flrigInterval); flrigInterval = null; vfoFreq = ""; vfoMode = ""; vfoPower = ""; vfoConnected = false; } }} on:shutdown-pending={() => { shutdownPendingSince = Date.now(); }} on:shutdown={() => { setShutdownState(); }} />
     {:else if page === "links"}
       <Links />
     {:else if page === "conditions"}
@@ -2020,6 +2026,12 @@
     font-size: 0.9rem;
     font-weight: bold;
     cursor: pointer;
+  }
+
+  .vfo-power {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin-left: 0.3rem;
   }
 
   .vfo-mode:hover {

--- a/frontend/src/Logbook.svelte
+++ b/frontend/src/Logbook.svelte
@@ -1226,7 +1226,7 @@
     </div>
     <div class="field" class:changed={orig && tx_pwr !== orig.tx_pwr}>
       <label for="tx_pwr">TX Pwr (W)</label>
-      <input id="tx_pwr" type="text" bind:value={tx_pwr} />
+      <input id="tx_pwr" type="number" bind:value={tx_pwr} min="0" step="any" />
     </div>
     <div class="field field-name" class:changed={orig && name !== orig.name}>
       <label for="name">Name</label>

--- a/frontend/src/Logbook.svelte
+++ b/frontend/src/Logbook.svelte
@@ -1226,7 +1226,7 @@
     </div>
     <div class="field" class:changed={orig && tx_pwr !== orig.tx_pwr}>
       <label for="tx_pwr">TX Pwr (W)</label>
-      <input id="tx_pwr" type="number" bind:value={tx_pwr} min="0" step="any" />
+      <input id="tx_pwr" type="text" inputmode="decimal" bind:value={tx_pwr} on:input={() => { tx_pwr = tx_pwr.replace(/[^0-9.]/g, "").replace(/(\..*)\./g, "$1"); }} />
     </div>
     <div class="field field-name" class:changed={orig && name !== orig.name}>
       <label for="name">Name</label>

--- a/frontend/src/Logbook.svelte
+++ b/frontend/src/Logbook.svelte
@@ -19,6 +19,7 @@
   export let prefill = null;
   export let vfoFreq = "";
   export let vfoMode = "";
+  export let vfoPower = "";
   const dispatch = createEventDispatcher();
 
   let contacts = [];
@@ -41,6 +42,7 @@
   let skcc = "";
   let skcc_exch = false;
   let cw_key_type = localStorage.getItem("rigbook_cw_key_type") || "";
+  let tx_pwr = "";
   let tableWrapEl;
   function utcNowDate() { return new Date().toISOString().slice(0, 10); }
   function utcNowTime() { return new Date().toISOString().slice(11, 19); }
@@ -211,7 +213,7 @@
   export let activePark = "";
 
   function formSnapshot() {
-    return { call, freq, mode, rst_sent, rst_recv, pota_park, name, qth, state, country, grid, skcc, skcc_exch, cw_key_type, comments, notes, datePart, timePart, datePartOff, timePartOff };
+    return { call, freq, mode, rst_sent, rst_recv, pota_park, name, qth, state, country, grid, skcc, skcc_exch, cw_key_type, tx_pwr, comments, notes, datePart, timePart, datePartOff, timePartOff };
   }
 
   $: editHasChanges = !editingId || !editOriginal || (
@@ -229,6 +231,7 @@
     skcc !== editOriginal.skcc ||
     skcc_exch !== editOriginal.skcc_exch ||
     cw_key_type !== editOriginal.cw_key_type ||
+    tx_pwr !== editOriginal.tx_pwr ||
     comments !== editOriginal.comments ||
     notes !== editOriginal.notes ||
     datePart !== editOriginal.datePart ||
@@ -257,6 +260,7 @@
     skcc !== addOriginal.skcc ||
     skcc_exch !== addOriginal.skcc_exch ||
     cw_key_type !== addOriginal.cw_key_type ||
+    tx_pwr !== addOriginal.tx_pwr ||
     comments !== addOriginal.comments ||
     notes !== addOriginal.notes ||
     (clockState === "STATIC" && datePart !== addOriginal.datePart) ||
@@ -287,6 +291,7 @@
     comments: { key: "comments", label: "Comments" },
     updated_at: { key: "updated_at", label: "Edited" },
     cw_key_type: { key: "cw_key_type", label: "CW Key" },
+    tx_pwr: { key: "tx_pwr", label: "TX Pwr" },
   };
 
   function loadColumnOrder() {
@@ -551,6 +556,7 @@
     skcc = "";
     skcc_exch = false;
     cw_key_type = localStorage.getItem("rigbook_cw_key_type") || "";
+    tx_pwr = "";
     comments = "";
     notes = "";
     datePart = "";
@@ -591,6 +597,10 @@
   $: if (!editingId && !prefill && !userTouched && vfoMode) {
     mode = vfoMode;
     if (addOriginal) addOriginal = { ...addOriginal, mode };
+  }
+  $: if (!editingId && !prefill && !userTouched && vfoPower) {
+    tx_pwr = vfoPower;
+    if (addOriginal) addOriginal = { ...addOriginal, tx_pwr };
   }
 
   let lastQrzCall = "";
@@ -841,6 +851,7 @@
     skcc = c.skcc || "";
     skcc_exch = !!c.skcc_exch;
     cw_key_type = c.cw_key_type || "";
+    tx_pwr = c.tx_pwr || "";
     comments = c.comments || "";
     notes = c.notes || "";
     if (c.timestamp) {
@@ -864,7 +875,7 @@
     errorMsg = "";
     editOriginal = {
       call, freq, mode, rst_sent, rst_recv, pota_park, name, qth,
-      state, country, grid, skcc, skcc_exch, cw_key_type, comments, notes, datePart, timePart,
+      state, country, grid, skcc, skcc_exch, cw_key_type, tx_pwr, comments, notes, datePart, timePart,
       datePartOff, timePartOff,
     };
     const match = countries.find(co => co.name === country);
@@ -921,6 +932,7 @@
         skcc: skcc.trim().toUpperCase() || null,
         skcc_exch: skcc_exch,
         cw_key_type: cw_key_type || null,
+        tx_pwr: tx_pwr.trim() || null,
         comments: comments || null,
         notes: notes || null,
         timestamp: `${datePart}T${timePart || "00:00:00"}Z`,
@@ -971,6 +983,7 @@
     skcc = "";
     skcc_exch = false;
     cw_key_type = localStorage.getItem("rigbook_cw_key_type") || "";
+    tx_pwr = "";
     comments = "";
     notes = "";
     datePart = "";
@@ -1013,6 +1026,7 @@
         skcc: skcc.trim().toUpperCase() || null,
         skcc_exch: skcc_exch,
         cw_key_type: cw_key_type || null,
+        tx_pwr: tx_pwr.trim() || null,
         comments: comments || null,
         notes: notes || null,
         timestamp: `${datePart}T${timePart || "00:00:00"}Z`,
@@ -1210,6 +1224,10 @@
       <label for="rst_recv">RST Recv</label>
       <input id="rst_recv" type="text" bind:value={rst_recv} />
     </div>
+    <div class="field" class:changed={orig && tx_pwr !== orig.tx_pwr}>
+      <label for="tx_pwr">TX Pwr (W)</label>
+      <input id="tx_pwr" type="text" bind:value={tx_pwr} />
+    </div>
     <div class="field field-name" class:changed={orig && name !== orig.name}>
       <label for="name">Name</label>
       <input id="name" type="text" bind:value={name} />
@@ -1398,6 +1416,7 @@
                 {:else if col.key === "comments"}<td class="truncate">{c.comments || ""}</td>
                 {:else if col.key === "updated_at"}<td>{c.updated_at ? formatTimestamp(c.updated_at) : ""}</td>
                 {:else if col.key === "cw_key_type"}<td>{c.cw_key_type || ""}</td>
+                {:else if col.key === "tx_pwr"}<td>{c.tx_pwr || ""}</td>
                 {/if}
               {/each}
             </tr>

--- a/src/rigbook/db.py
+++ b/src/rigbook/db.py
@@ -176,6 +176,7 @@ class Contact(Base):
     skcc: Mapped[str | None] = mapped_column(String, nullable=True)
     skcc_exch: Mapped[int | None] = mapped_column(Integer, nullable=True, default=0)
     cw_key_type: Mapped[str | None] = mapped_column(String, nullable=True)
+    tx_pwr: Mapped[str | None] = mapped_column(String, nullable=True)
     comments: Mapped[str | None] = mapped_column(String, nullable=True)
     notes: Mapped[str | None] = mapped_column(String, nullable=True)
     timestamp: Mapped[datetime] = mapped_column(

--- a/src/rigbook/flrig.py
+++ b/src/rigbook/flrig.py
@@ -86,7 +86,7 @@ class FlrigClient:
     def get_power(self) -> str | None:
         try:
             server = xmlrpc.client.ServerProxy(self.url)
-            return server.rig.get_power()
+            return str(server.rig.get_power())
         except Exception:
             return None
 

--- a/src/rigbook/flrig.py
+++ b/src/rigbook/flrig.py
@@ -18,6 +18,7 @@ SIMULATED_MODES = ["CW", "USB", "LSB", "RTTY", "FT8"]
 # --- Simulated radio state ---
 _sim_freq: str = "14074000"
 _sim_mode: str = "CW"
+_sim_power: str = "100"
 
 
 async def is_simulate(session: AsyncSession) -> bool:
@@ -34,6 +35,7 @@ async def get_flrig_url(session: AsyncSession = Depends(get_session)) -> str:
 class FlrigStatus(BaseModel):
     freq: str | None = None
     mode: str | None = None
+    power: str | None = None
     connected: bool = False
 
 
@@ -81,6 +83,13 @@ class FlrigClient:
         except Exception:
             return False
 
+    def get_power(self) -> str | None:
+        try:
+            server = xmlrpc.client.ServerProxy(self.url)
+            return server.rig.get_power()
+        except Exception:
+            return None
+
 
 class FlrigSet(BaseModel):
     freq: str | None = None
@@ -93,13 +102,16 @@ async def flrig_status(
     session: AsyncSession = Depends(get_session),
 ):
     if await is_simulate(session):
-        return FlrigStatus(freq=_sim_freq, mode=_sim_mode, connected=True)
+        return FlrigStatus(
+            freq=_sim_freq, mode=_sim_mode, power=_sim_power, connected=True
+        )
     loop = asyncio.get_event_loop()
     client = FlrigClient(url)
     freq = await loop.run_in_executor(None, client.get_frequency)
     mode = await loop.run_in_executor(None, client.get_mode)
+    power = await loop.run_in_executor(None, client.get_power)
     connected = freq is not None
-    return FlrigStatus(freq=freq, mode=mode, connected=connected)
+    return FlrigStatus(freq=freq, mode=mode, power=power, connected=connected)
 
 
 @router.get("/modes")

--- a/src/rigbook/routes/adif.py
+++ b/src/rigbook/routes/adif.py
@@ -145,6 +145,7 @@ def render_comment_with_template(
         "skcc": c.skcc,
         "skcc_exch": "Y" if c.skcc_exch else "",
         "cw_key_type": c.cw_key_type or "",
+        "tx_pwr": c.tx_pwr or "",
         "dxcc": str(c.dxcc) if c.dxcc is not None else "",
     }
     parts = []
@@ -199,6 +200,8 @@ def contact_to_adif_record(
         record["APP_RIGBOOK_SKCC_EXCH"] = "Y"
     if c.cw_key_type:
         record["APP_RIGBOOK_CW_KEY_TYPE"] = c.cw_key_type
+    if c.tx_pwr:
+        record["TX_PWR"] = c.tx_pwr
     if comment_template:
         comment = render_comment_with_template(comment_template, c, comment_separator)
         if comment:
@@ -390,6 +393,9 @@ def adif_record_to_contact_dict(record: dict) -> dict:
     )
     if cw_key_type:
         data["cw_key_type"] = cw_key_type
+    tx_pwr = record.get("TX_PWR")
+    if tx_pwr:
+        data["tx_pwr"] = tx_pwr
     data["comments"] = record.get("COMMENT")
     data["notes"] = record.get("NOTES")
     app_uuid = record.get("APP_RIGBOOK_UUID")
@@ -763,6 +769,7 @@ MERGE_FIELDS = [
     ("skcc", "SKCC"),
     ("skcc_exch", "SKCC Exch"),
     ("cw_key_type", "CW Key"),
+    ("tx_pwr", "TX Pwr"),
     ("comments", "Comments"),
     ("notes", "Notes"),
 ]
@@ -957,6 +964,7 @@ ADIF_FIELD_MAP = {
     "DXCC": "dxcc",
     "APP_RIGBOOK_CW_KEY_TYPE": "cw_key_type",
     "APP_SKCCLOGGER_KEYTYPE": "cw_key_type",
+    "TX_PWR": "tx_pwr",
 }
 
 DEFAULT_LABELS = {
@@ -974,6 +982,7 @@ DEFAULT_LABELS = {
     "skcc": "SKCC",
     "skcc_exch": "SKCC Exch",
     "cw_key_type": "CW Key",
+    "tx_pwr": "TX Pwr",
     "dxcc": "DXCC",
 }
 
@@ -1101,6 +1110,7 @@ async def preview_import_adif(
             "skcc": data.get("skcc"),
             "skcc_exch": bool(data.get("skcc_exch")),
             "cw_key_type": data.get("cw_key_type"),
+            "tx_pwr": data.get("tx_pwr"),
             "comments": data.get("comments"),
             "original_comment": data.get("_original_comment"),
             "notes": data.get("notes"),
@@ -1187,6 +1197,7 @@ IMPORT_FIELDS = {
     "skcc",
     "skcc_exch",
     "cw_key_type",
+    "tx_pwr",
     "comments",
     "notes",
     "timestamp_off",

--- a/src/rigbook/routes/contacts.py
+++ b/src/rigbook/routes/contacts.py
@@ -67,6 +67,20 @@ class ContactCreate(BaseModel):
             raise ValueError("grid must be alphanumeric with no spaces")
         return v.upper()
 
+    @field_validator("tx_pwr")
+    @classmethod
+    def validate_tx_pwr(cls, v: str | None) -> str | None:
+        if not v:
+            return None
+        v = v.strip()
+        if not v:
+            return None
+        try:
+            float(v)
+        except ValueError:
+            raise ValueError("TX power must be a number")
+        return v
+
     @field_validator("timestamp", "timestamp_off")
     @classmethod
     def normalize_timestamp(cls, v: datetime | None) -> datetime | None:
@@ -106,6 +120,20 @@ class ContactUpdate(BaseModel):
     notes: str | None = None
     timestamp: datetime | None = None
     timestamp_off: datetime | None = None
+
+    @field_validator("tx_pwr")
+    @classmethod
+    def validate_tx_pwr(cls, v: str | None) -> str | None:
+        if not v:
+            return None
+        v = v.strip()
+        if not v:
+            return None
+        try:
+            float(v)
+        except ValueError:
+            raise ValueError("TX power must be a number")
+        return v
 
     @field_validator("timestamp", "timestamp_off")
     @classmethod

--- a/src/rigbook/routes/contacts.py
+++ b/src/rigbook/routes/contacts.py
@@ -31,6 +31,7 @@ class ContactCreate(BaseModel):
     skcc: str | None = None
     skcc_exch: bool = False
     cw_key_type: str | None = None
+    tx_pwr: str | None = None
     comments: str | None = None
     notes: str | None = None
     timestamp: datetime | None = None
@@ -100,6 +101,7 @@ class ContactUpdate(BaseModel):
     skcc: str | None = None
     skcc_exch: bool | None = None
     cw_key_type: str | None = None
+    tx_pwr: str | None = None
     comments: str | None = None
     notes: str | None = None
     timestamp: datetime | None = None
@@ -145,6 +147,7 @@ class ContactResponse(BaseModel):
     skcc: str | None
     skcc_exch: bool = False
     cw_key_type: str | None = None
+    tx_pwr: str | None = None
     comments: str | None
     notes: str | None
     timestamp: datetime


### PR DESCRIPTION
Closes #194 (sub-issue of #191, part 2)

## Summary

- Adds `tx_pwr` field to QSO contacts, auto-populated from flrig via `rig.get_power()` XMLRPC
- Power displayed in VFO header area after mode (e.g. "CW 100W")
- Auto-fills form like freq/mode — updates from flrig poll until user touches the form
- ADIF export/import uses standard `TX_PWR` field
- Column available in log table via column picker

## Files changed

- `src/rigbook/flrig.py` — `get_power()` on FlrigClient, power in FlrigStatus/status endpoint, simulated power
- `src/rigbook/db.py` — new `tx_pwr` column on Contact model
- `src/rigbook/routes/contacts.py` — added to Pydantic models
- `src/rigbook/routes/adif.py` — TX_PWR export/import, field maps, merge fields
- `frontend/src/App.svelte` — vfoPower polling, VFO header display, prop pass-through
- `frontend/src/Logbook.svelte` — form field with VFO auto-fill, table column