### PR TITLE
Treat CW-R and CWR modes as CW for CW-related fields

### DIFF
--- a/frontend/src/Logbook.svelte
+++ b/frontend/src/Logbook.svelte
@@ -1205,7 +1205,7 @@
       <label>Mode *</label>
       <Autocomplete bind:value={mode} items={availableModes} />
     </div>
-    {#if mode.toUpperCase() === "CW"}
+    {#if mode.toUpperCase().startsWith("CW")}
     <div class="field" class:changed={orig && cw_key_type !== orig.cw_key_type}>
       <label for="cw_key_type">CW Key{#if cw_key_type === "SK"} — Straight{:else if cw_key_type === "BUG"} — Bug{:else if cw_key_type === "SS"} — Sideswiper{/if}</label>
       <select id="cw_key_type" bind:value={cw_key_type}>
@@ -1291,7 +1291,7 @@
         {/if}
       </div>
     </div>
-    {#if mode.toUpperCase() === "CW"}
+    {#if mode.toUpperCase().startsWith("CW")}
     <div class="field" class:changed={orig && (skcc !== orig.skcc || skcc_exch !== orig.skcc_exch)}>
       <label for="skcc">SKCC # / {skcc_exch ? "Validated!" : "Validated?"}</label>
       <div class="skcc-input-row">

--- a/frontend/src/SkccSkimmer.svelte
+++ b/frontend/src/SkccSkimmer.svelte
@@ -84,7 +84,7 @@
     }
   }
 
-  $: visible = !filterMode || filterMode === "CW";
+  $: visible = !filterMode || filterMode.toUpperCase().startsWith("CW");
 
   // Force spots re-render when workedTodayKeys changes
   $: if (workedTodayKeys) { spots = [...spots]; }

--- a/frontend/src/Spots.svelte
+++ b/frontend/src/Spots.svelte
@@ -279,7 +279,7 @@
   }
 
   let spotColumnOrder = loadSpotColumnOrder();
-  $: spotColumns = spotColumnOrder.filter(k => k !== "skcc" || filterMode === "CW").map(k => spotColumnDefs[k]);
+  $: spotColumns = spotColumnOrder.filter(k => k !== "skcc" || filterMode.toUpperCase().startsWith("CW")).map(k => spotColumnDefs[k]);
 
   let spotDragCol = null;
   let spotDragOverCol = null;
@@ -1497,14 +1497,14 @@
       <option value="rbn">RBN</option>
       <option value="hamalert">HamAlert</option>
     </select>
-    <select bind:value={filterMode} on:change={() => { if (filterMode !== "CW") filterSkcc = ""; onFilterChange(); }}>
+    <select bind:value={filterMode} on:change={() => { if (!filterMode.toUpperCase().startsWith("CW")) filterSkcc = ""; onFilterChange(); }}>
       <option value="">All Modes</option>
       {#each modeList as m}
         <option value={m}>{m} ({modes[m]})</option>
       {/each}
     </select>
     <input type="text" placeholder="Callsign" bind:value={filterCallsign} on:input={onFilterChange} style="text-transform: uppercase; width: 10ch" />
-    {#if filterMode === "CW"}
+    {#if filterMode.toUpperCase().startsWith("CW")}
       <select bind:value={filterSkcc} on:change={onFilterChange}>
         <option value="">SKCC: Any</option>
         <option value="required">SKCC: Required</option>

--- a/src/rigbook/routes/contacts.py
+++ b/src/rigbook/routes/contacts.py
@@ -243,7 +243,7 @@ async def today_cw_contacts(session: AsyncSession = Depends(get_session)):
     rows = (
         await session.execute(
             select(Contact.call, Contact.freq, Contact.mode)
-            .where(Contact.mode == "CW")
+            .where(Contact.mode.like("CW%"))
             .where(Contact.timestamp >= today_start)
         )
     ).all()

--- a/src/rigbook/routes/spots.py
+++ b/src/rigbook/routes/spots.py
@@ -95,7 +95,7 @@ async def query_spots(
     cw_calls = [
         c
         for c in all_calls
-        if any(s["callsign"].upper() == c and s["mode"] == "CW" for s in spots)
+        if any(s["callsign"].upper() == c and s["mode"].upper().startswith("CW") for s in spots)
     ]
     if cw_calls:
         await ensure_skcc_cache(gdb)


### PR DESCRIPTION
- Use `startsWith("CW")` instead of exact `=== "CW"` checks so CW-R, CWR, and other CW variants show CW key type, SKCC fields, and appear in CW-related queries
- Fixes #196